### PR TITLE
feat(wallet): MVP read-only — BalanceDisplay, sidebar y página de historial

### DIFF
--- a/app/(app)/wallet/WalletClient.tsx
+++ b/app/(app)/wallet/WalletClient.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ArrowDown, ArrowUp, CreditCard, Plus, ArrowUpFromSquare } from "@gravity-ui/icons";
+import { Button } from "@heroui/react/button";
+
+import PageHero from "@/components/ui/PageHero";
+import { AuthGuard } from "@/components/ui/AuthGuard/AuthGuard";
+import { useBalance, useInfiniteTransactions } from "@/lib/hooks/use-wallet";
+import { groupByCurrency, labelForKind } from "@/features/wallet/shared";
+import {
+    formatCurrency,
+    formatSignedCurrency,
+    isCreditTx,
+    timeAgo,
+} from "@/lib/utils/format";
+import type { WalletTransaction } from "@/lib/types/wallet";
+
+// ── Balance cards ──
+
+function BalanceCards() {
+    const { data, isLoading } = useBalance();
+    const groups = useMemo(() => groupByCurrency(data?.accounts), [data]);
+
+    if (isLoading && !data) {
+        return (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mx-4 lg:mx-6 mb-4">
+                {[...Array(2)].map((_, i) => (
+                    <div
+                        key={i}
+                        className="rounded-2xl p-5 h-[128px] animate-pulse"
+                        style={{ backgroundColor: "var(--surface-solid)", border: "1px solid var(--border)" }}
+                    />
+                ))}
+            </div>
+        );
+    }
+
+    if (groups.length === 0) {
+        return (
+            <div className="mx-4 lg:mx-6 mb-4">
+                <div
+                    className="rounded-2xl p-5"
+                    style={{ backgroundColor: "var(--surface-solid)", border: "1px solid var(--border)" }}
+                >
+                    <div className="flex items-center gap-3">
+                        <div className="w-10 h-10 rounded-full flex items-center justify-center bg-accent/15 text-accent">
+                            <CreditCard className="size-5" />
+                        </div>
+                        <div>
+                            <p className="text-[12px] uppercase font-bold tracking-wider m-0 text-muted">
+                                Saldo disponible
+                            </p>
+                            <p className="text-[24px] font-extrabold tabular-nums m-0 text-foreground">
+                                {formatCurrency(0, "CLP")}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mx-4 lg:mx-6 mb-4">
+            {groups.map((g) => (
+                <div
+                    key={g.currency}
+                    className="rounded-2xl p-5 relative overflow-hidden"
+                    style={{
+                        background:
+                            "linear-gradient(135deg, var(--accent) 0%, color-mix(in oklab, var(--accent) 60%, #000) 100%)",
+                        color: "#fff",
+                    }}
+                >
+                    <div className="flex items-center justify-between mb-1">
+                        <p className="text-[11px] uppercase tracking-wider font-bold opacity-80 m-0">
+                            Saldo disponible
+                        </p>
+                        <span className="text-[10px] font-extrabold opacity-80">{g.currency}</span>
+                    </div>
+                    <p className="text-[32px] font-extrabold leading-tight m-0 mb-3 tabular-nums">
+                        {formatCurrency(g.available, g.currency)}
+                    </p>
+                    <div className="flex items-center justify-between text-[11px] opacity-90">
+                        <div>
+                            <p className="m-0 opacity-75">En reserva</p>
+                            <p className="m-0 font-bold tabular-nums">
+                                {formatCurrency(g.holds, g.currency)}
+                            </p>
+                        </div>
+                        <div className="text-right">
+                            <p className="m-0 opacity-75">Total</p>
+                            <p className="m-0 font-bold tabular-nums">
+                                {formatCurrency(g.total, g.currency)}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+// ── Transaction row — desktop table ──
+
+function TxDesktopRow({ tx }: { tx: WalletTransaction }) {
+    const credit = isCreditTx(tx.kind);
+    const currency = tx.currency || "CLP";
+    return (
+        <div
+            className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 px-5 py-3 border-b"
+            style={{ borderColor: "var(--border)" }}
+        >
+            <div
+                className="w-9 h-9 rounded-full flex items-center justify-center shrink-0"
+                style={{
+                    backgroundColor: credit ? "rgba(0,178,75,0.12)" : "rgba(246,61,0,0.12)",
+                    color: credit ? "#00b24b" : "#f63d00",
+                }}
+                aria-hidden="true"
+            >
+                {credit ? <ArrowDown className="size-4" /> : <ArrowUp className="size-4" />}
+            </div>
+            <div className="min-w-0">
+                <p className="text-[13px] font-semibold text-foreground m-0 truncate">
+                    {labelForKind(tx.kind)}
+                </p>
+                <p className="text-[11px] m-0 truncate" style={{ color: "var(--muted)" }}>
+                    {tx.reference_type ? `${tx.reference_type} · ` : ""}
+                    {timeAgo(tx.created_at, { verbose: true, fallbackDays: 30 })}
+                </p>
+            </div>
+            <p
+                className="text-[13px] font-bold tabular-nums m-0 text-right"
+                style={{ color: credit ? "#00b24b" : "#f63d00" }}
+            >
+                {formatSignedCurrency(tx.amount, currency)}
+            </p>
+            <p
+                className="text-[12px] tabular-nums m-0 text-right hidden md:block"
+                style={{ color: "var(--muted)" }}
+            >
+                Saldo: {formatCurrency(tx.balance_after, currency)}
+            </p>
+        </div>
+    );
+}
+
+// ── Main wallet page (behind AuthGuard) ──
+
+function WalletContent() {
+    const [kindFilter, setKindFilter] = useState<string>("ALL");
+    const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+        useInfiniteTransactions(20);
+
+    const allTxs: WalletTransaction[] = useMemo(() => {
+        if (!data?.pages) return [];
+        return data.pages.flatMap((p) => p.transactions);
+    }, [data]);
+
+    const availableKinds = useMemo(() => {
+        const s = new Set<string>();
+        for (const t of allTxs) s.add(t.kind);
+        return Array.from(s);
+    }, [allTxs]);
+
+    const filtered = useMemo(() => {
+        if (kindFilter === "ALL") return allTxs;
+        return allTxs.filter((t) => t.kind === kindFilter);
+    }, [allTxs, kindFilter]);
+
+    const emptyFirstLoad = !isLoading && allTxs.length === 0;
+
+    return (
+        <div className="max-w-5xl mx-auto flex flex-col min-h-full">
+            <PageHero
+                badge="Wallet"
+                title="Mi wallet"
+                subtitle="Tu saldo disponible y el historial de movimientos en Rankeao."
+                action={
+                    <div className="hidden md:flex flex-col gap-2 min-w-[140px]" title="Próximamente">
+                        <Button
+                            size="sm"
+                            variant="primary"
+                            isDisabled
+                            className="font-bold"
+                            aria-label="Recargar saldo (próximamente)"
+                        >
+                            <Plus className="size-3.5 mr-1.5" />
+                            Recargar
+                        </Button>
+                        <Button
+                            size="sm"
+                            variant="tertiary"
+                            isDisabled
+                            className="font-bold"
+                            aria-label="Retirar saldo (próximamente)"
+                        >
+                            <ArrowUpFromSquare className="size-3.5 mr-1.5" />
+                            Retirar
+                        </Button>
+                    </div>
+                }
+            />
+
+            <BalanceCards />
+
+            {/* Filter chips */}
+            {availableKinds.length > 1 && (
+                <div className="mx-4 lg:mx-6 mb-3 flex flex-wrap gap-2">
+                    {(["ALL", ...availableKinds] as const).map((k) => {
+                        const active = kindFilter === k;
+                        return (
+                            <button
+                                key={k}
+                                type="button"
+                                onClick={() => setKindFilter(k)}
+                                className="px-3 py-1.5 rounded-full text-[12px] font-semibold whitespace-nowrap cursor-pointer transition-colors"
+                                style={{
+                                    backgroundColor: active ? "var(--foreground)" : "var(--surface-solid)",
+                                    color: active ? "var(--background)" : "var(--muted)",
+                                    border: active ? "none" : "1px solid var(--border)",
+                                }}
+                            >
+                                {k === "ALL" ? "Todos" : labelForKind(k)}
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
+
+            {/* Transactions list */}
+            <div className="mx-4 lg:mx-6 mb-10">
+                <div
+                    className="rounded-2xl overflow-hidden"
+                    style={{ backgroundColor: "var(--surface-solid)", border: "1px solid var(--border)" }}
+                >
+                    <div
+                        className="grid grid-cols-[auto_1fr_auto_auto] gap-4 px-5 py-3 text-[11px] font-bold uppercase tracking-wider"
+                        style={{ color: "var(--muted)", borderBottom: "1px solid var(--border)" }}
+                    >
+                        <span className="w-9" aria-hidden="true" />
+                        <span>Movimiento</span>
+                        <span className="text-right">Monto</span>
+                        <span className="text-right hidden md:block">Saldo resultante</span>
+                    </div>
+
+                    {isLoading && allTxs.length === 0 ? (
+                        <div>
+                            {[...Array(6)].map((_, i) => (
+                                <div
+                                    key={i}
+                                    className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 px-5 py-3 animate-pulse border-b"
+                                    style={{ borderColor: "var(--border)" }}
+                                >
+                                    <div
+                                        className="w-9 h-9 rounded-full"
+                                        style={{ backgroundColor: "var(--surface)" }}
+                                    />
+                                    <div className="space-y-2">
+                                        <div
+                                            className="h-3 rounded w-2/5"
+                                            style={{ backgroundColor: "var(--surface)" }}
+                                        />
+                                        <div
+                                            className="h-2.5 rounded w-1/4"
+                                            style={{ backgroundColor: "var(--surface)" }}
+                                        />
+                                    </div>
+                                    <div
+                                        className="h-3 w-20 rounded"
+                                        style={{ backgroundColor: "var(--surface)" }}
+                                    />
+                                    <div
+                                        className="h-3 w-24 rounded hidden md:block"
+                                        style={{ backgroundColor: "var(--surface)" }}
+                                    />
+                                </div>
+                            ))}
+                        </div>
+                    ) : emptyFirstLoad ? (
+                        <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+                            <div
+                                className="w-16 h-16 rounded-full flex items-center justify-center mb-4"
+                                style={{ backgroundColor: "var(--surface)" }}
+                            >
+                                <CreditCard
+                                    style={{ width: 28, height: 28, color: "var(--muted)", opacity: 0.4 }}
+                                />
+                            </div>
+                            <p className="text-sm font-semibold m-0" style={{ color: "var(--foreground)" }}>
+                                Aún no tienes movimientos
+                            </p>
+                            <p className="text-xs mt-1 mb-4" style={{ color: "var(--muted)" }}>
+                                Cuando recibas o gastes saldo aparecerá aquí.
+                            </p>
+                            <Button
+                                size="sm"
+                                variant="primary"
+                                isDisabled
+                                aria-label="Recargar saldo (próximamente)"
+                            >
+                                Recargar saldo (próximamente)
+                            </Button>
+                        </div>
+                    ) : filtered.length === 0 ? (
+                        <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
+                            <p className="text-sm font-semibold m-0" style={{ color: "var(--foreground)" }}>
+                                Sin resultados para este filtro
+                            </p>
+                            <p className="text-xs mt-1 m-0" style={{ color: "var(--muted)" }}>
+                                Prueba con otra categoría o con &quot;Todos&quot;.
+                            </p>
+                        </div>
+                    ) : (
+                        <div>
+                            {filtered.map((tx) => (
+                                <TxDesktopRow key={tx.id} tx={tx} />
+                            ))}
+                        </div>
+                    )}
+                </div>
+
+                {/* Load more */}
+                {hasNextPage && (
+                    <div className="flex justify-center mt-6">
+                        <Button
+                            size="sm"
+                            variant="tertiary"
+                            onPress={() => fetchNextPage()}
+                            isPending={isFetchingNextPage}
+                            isDisabled={isFetchingNextPage}
+                            className="font-semibold"
+                        >
+                            {isFetchingNextPage ? "Cargando..." : "Cargar más"}
+                        </Button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default function WalletClient() {
+    return (
+        <AuthGuard>
+            <WalletContent />
+        </AuthGuard>
+    );
+}

--- a/app/(app)/wallet/page.tsx
+++ b/app/(app)/wallet/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import WalletClient from "./WalletClient";
+
+export const metadata: Metadata = {
+    title: "Mi wallet",
+    description: "Saldo disponible, reservas y movimientos de tu wallet en Rankeao.",
+    robots: { index: false, follow: false },
+};
+
+export default function WalletPage() {
+    return <WalletClient />;
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import LoginForm from "./LoginForm";
 
 export const metadata = {
@@ -5,5 +6,9 @@ export const metadata = {
 };
 
 export default function LoginPage() {
-  return <LoginForm />;
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  );
 }

--- a/components/layout/Navbar/Navbar.tsx
+++ b/components/layout/Navbar/Navbar.tsx
@@ -35,6 +35,8 @@ import { getUserProfile } from "@/lib/api/social";
 import type { UserProfile } from "@/lib/types/social";
 
 const NotificationSidebar = dynamic(() => import("@/components/layout/NotificationSidebar"), { ssr: false });
+const BalanceDisplay = dynamic(() => import("@/features/wallet/BalanceDisplay"), { ssr: false });
+const BalanceSidebar = dynamic(() => import("@/features/wallet/BalanceSidebar"), { ssr: false });
 
 const authPages = ["/login", "/register", "/forgot-password", "/reset-password", "/verify-email", "/duels/session"];
 
@@ -54,6 +56,7 @@ export default function Navbar() {
   const notifSidebarOpen = useUIStore((s) => s.notificationSidebarOpen);
   const openNotifSidebar = useUIStore((s) => s.openNotificationSidebar);
   const closeNotifSidebar = useUIStore((s) => s.closeNotificationSidebar);
+  const balanceSidebarOpen = useUIStore((s) => s.balanceSidebarOpen);
   const unreadCount = useUIStore((s) => s.notificationUnreadCount);
   const setUnreadCount = useUIStore((s) => s.setNotificationUnreadCount);
   const userAvatarUrl = useAuthStore((s) => s.avatarUrl);
@@ -157,6 +160,9 @@ export default function Navbar() {
                   <Magnifier className="size-4 text-muted" />
                 </button>
 
+                {/* Wallet balance (mobile) */}
+                {isAuthenticated && <BalanceDisplay variant="mobile" />}
+
                 {/* Bell */}
                 {isAuthenticated && (
                   <button
@@ -214,6 +220,9 @@ export default function Navbar() {
 
                 {isAuthenticated ? (
                   <>
+                    {/* Wallet balance (desktop) */}
+                    <BalanceDisplay variant="desktop" />
+
                     {/* Notifications — opens sidebar */}
                     <button
                       onClick={() => openNotifSidebar()}
@@ -378,6 +387,8 @@ export default function Navbar() {
         accessToken={session?.accessToken}
         onUnreadCountChange={setUnreadCount}
       />
+
+      {isAuthenticated && balanceSidebarOpen && <BalanceSidebar />}
     </header>
   );
 }

--- a/features/wallet/BalanceDisplay/BalanceDisplay.tsx
+++ b/features/wallet/BalanceDisplay/BalanceDisplay.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { CreditCard } from "@gravity-ui/icons";
+import { useBalance } from "@/lib/hooks/use-wallet";
+import { useAuthStore } from "@/lib/stores/auth-store";
+import { useUIStore } from "@/lib/stores/ui-store";
+import { pickAvailableCLP } from "@/features/wallet/shared";
+import { formatCurrency } from "@/lib/utils/format";
+
+interface Props {
+    variant?: "desktop" | "mobile";
+}
+
+/**
+ * Compact balance pill for the navbar. Clicking it opens the BalanceSidebar.
+ * Renders nothing if the user is not authenticated.
+ */
+export default function BalanceDisplay({ variant = "desktop" }: Props) {
+    const accessToken = useAuthStore((s) => s.accessToken);
+    const isAuthenticated = !!accessToken;
+    const openBalanceSidebar = useUIStore((s) => s.openBalanceSidebar);
+    const { data, isLoading } = useBalance();
+
+    if (!isAuthenticated) return null;
+
+    const clp = pickAvailableCLP(data?.accounts);
+    const amount = clp?.available ?? "0";
+
+    if (variant === "mobile") {
+        // Compact icon-only tile, matching the other navbar mobile buttons.
+        return (
+            <button
+                type="button"
+                onClick={() => openBalanceSidebar()}
+                className="w-10 h-10 rounded-full flex items-center justify-center cursor-pointer bg-surface-solid"
+                aria-label={
+                    isLoading
+                        ? "Cargando saldo"
+                        : `Mi saldo: ${formatCurrency(amount, clp?.currency ?? "CLP")}`
+                }
+            >
+                <CreditCard className="size-4 text-muted" />
+            </button>
+        );
+    }
+
+    if (isLoading && !data) {
+        return (
+            <div
+                className="h-9 min-w-[88px] rounded-full px-3 flex items-center gap-2 bg-surface-solid animate-pulse"
+                aria-label="Cargando saldo"
+            >
+                <div className="size-4 rounded-full bg-foreground/10" />
+                <div className="h-3 w-14 rounded bg-foreground/10" />
+            </div>
+        );
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={() => openBalanceSidebar()}
+            className="group h-9 px-3 rounded-full flex items-center gap-2 bg-surface-solid hover:bg-foreground/5 cursor-pointer transition-colors outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            aria-label={`Mi saldo: ${formatCurrency(amount, clp?.currency ?? "CLP")}`}
+        >
+            <span className="flex items-center justify-center size-5 rounded-full bg-accent/15 text-accent">
+                <CreditCard className="size-3.5" />
+            </span>
+            <span className="text-[13px] font-bold text-foreground tabular-nums">
+                {formatCurrency(amount, clp?.currency ?? "CLP")}
+            </span>
+        </button>
+    );
+}

--- a/features/wallet/BalanceDisplay/index.ts
+++ b/features/wallet/BalanceDisplay/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BalanceDisplay";

--- a/features/wallet/BalanceSidebar/BalanceSidebar.tsx
+++ b/features/wallet/BalanceSidebar/BalanceSidebar.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import Link from "next/link";
+import { ScrollShadow } from "@heroui/react/scroll-shadow";
+import {
+    Xmark,
+    CreditCard,
+    ArrowDown,
+    ArrowUp,
+    Plus,
+    ArrowUpFromSquare,
+} from "@gravity-ui/icons";
+
+import { useBalance, useTransactions } from "@/lib/hooks/use-wallet";
+import { useUIStore } from "@/lib/stores/ui-store";
+import { pickAvailableCLP, labelForKind } from "@/features/wallet/shared";
+import {
+    formatCurrency,
+    formatSignedCurrency,
+    formatRelativeTime,
+    isCreditTx,
+} from "@/lib/utils/format";
+import type { WalletTransaction } from "@/lib/types/wallet";
+
+function TransactionRow({ tx }: { tx: WalletTransaction }) {
+    const credit = isCreditTx(tx.kind);
+    const label = labelForKind(tx.kind);
+    const currency = tx.currency || "CLP";
+
+    return (
+        <div className="flex items-center gap-3 px-5 py-3 transition-colors hover:bg-foreground/5">
+            <div
+                className="w-9 h-9 rounded-full flex items-center justify-center shrink-0"
+                style={{
+                    backgroundColor: credit ? "rgba(0,178,75,0.12)" : "rgba(246,61,0,0.12)",
+                    color: credit ? "#00b24b" : "#f63d00",
+                }}
+                aria-hidden="true"
+            >
+                {credit ? <ArrowDown className="size-4" /> : <ArrowUp className="size-4" />}
+            </div>
+            <div className="flex-1 min-w-0">
+                <p className="text-[13px] font-semibold text-foreground m-0 truncate">{label}</p>
+                <p className="text-[11px] m-0" style={{ color: "var(--muted)" }}>
+                    {formatRelativeTime(tx.created_at)}
+                </p>
+            </div>
+            <p
+                className="text-[13px] font-bold tabular-nums m-0 shrink-0"
+                style={{ color: credit ? "#00b24b" : "#f63d00" }}
+            >
+                {formatSignedCurrency(tx.amount, currency)}
+            </p>
+        </div>
+    );
+}
+
+export default function BalanceSidebar() {
+    const isOpen = useUIStore((s) => s.balanceSidebarOpen);
+    const onClose = useUIStore((s) => s.closeBalanceSidebar);
+    const panelRef = useRef<HTMLDivElement>(null);
+
+    const { data: balanceData, isLoading: balanceLoading } = useBalance();
+    const { data: txData, isLoading: txLoading } = useTransactions({ limit: 4 });
+
+    const clp = useMemo(() => pickAvailableCLP(balanceData?.accounts), [balanceData]);
+    const currency = clp?.currency ?? "CLP";
+    const available = clp?.available ?? "0";
+    const holds = clp?.holds_active ?? "0";
+    const transactions = txData?.transactions ?? [];
+
+    // ── Focus trap + Escape to close ──
+    useEffect(() => {
+        if (!isOpen) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                onClose();
+                return;
+            }
+            if (e.key === "Tab" && panelRef.current) {
+                const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+                    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+                );
+                if (focusable.length === 0) return;
+                const first = focusable[0];
+                const last = focusable[focusable.length - 1];
+                if (e.shiftKey && document.activeElement === first) {
+                    e.preventDefault();
+                    last.focus();
+                } else if (!e.shiftKey && document.activeElement === last) {
+                    e.preventDefault();
+                    first.focus();
+                }
+            }
+        };
+        document.addEventListener("keydown", handler);
+        requestAnimationFrame(() => {
+            const closeBtn = panelRef.current?.querySelector<HTMLElement>('[aria-label="Cerrar"]');
+            closeBtn?.focus();
+        });
+        return () => document.removeEventListener("keydown", handler);
+    }, [isOpen, onClose]);
+
+    // ── Lock body scroll while open ──
+    useEffect(() => {
+        document.body.style.overflow = isOpen ? "hidden" : "";
+        return () => {
+            document.body.style.overflow = "";
+        };
+    }, [isOpen]);
+
+    return (
+        <>
+            {/* Backdrop */}
+            <button
+                type="button"
+                aria-label="Cerrar saldo"
+                className={`fixed inset-0 z-[59] border-0 bg-black/50 p-0 transition-opacity duration-200 ${
+                    isOpen ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+                }`}
+                onClick={onClose}
+            />
+
+            {/* Sidebar panel — slides from the RIGHT, opposite to NotificationSidebar */}
+            <div
+                ref={panelRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Mi saldo"
+                className="fixed top-0 right-0 h-full z-[60] w-[420px] max-w-[calc(100vw-48px)] flex flex-col"
+                style={{
+                    background: "var(--background)",
+                    borderLeft: "1px solid var(--border)",
+                    transform: isOpen ? "translateX(0)" : "translateX(100%)",
+                    transition: "transform 250ms cubic-bezier(0.32,0.72,0,1)",
+                }}
+            >
+                {/* Header */}
+                <div
+                    className="flex items-center justify-between px-5 py-4 shrink-0"
+                    style={{ borderBottom: "1px solid var(--border)" }}
+                >
+                    <div className="flex items-center gap-2.5">
+                        <div className="w-8 h-8 rounded-full flex items-center justify-center bg-accent/15 text-accent">
+                            <CreditCard className="size-4" />
+                        </div>
+                        <h2 className="text-[17px] font-bold m-0" style={{ color: "var(--foreground)" }}>
+                            Mi saldo
+                        </h2>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="w-8 h-8 flex items-center justify-center rounded-full cursor-pointer transition-colors hover:bg-foreground/5"
+                        style={{ color: "var(--muted)" }}
+                        aria-label="Cerrar"
+                    >
+                        <Xmark style={{ width: 16, height: 16 }} />
+                    </button>
+                </div>
+
+                {/* Balance card */}
+                <div className="px-5 pt-5 pb-4 shrink-0">
+                    <div
+                        className="rounded-2xl p-5 relative overflow-hidden"
+                        style={{
+                            background:
+                                "linear-gradient(135deg, var(--accent) 0%, color-mix(in oklab, var(--accent) 60%, #000) 100%)",
+                            color: "#fff",
+                        }}
+                    >
+                        <div className="flex items-center justify-between mb-1">
+                            <p className="text-[11px] uppercase tracking-wider font-bold opacity-80 m-0">
+                                Saldo disponible
+                            </p>
+                            <span className="text-[10px] font-extrabold opacity-80">{currency}</span>
+                        </div>
+                        {balanceLoading && !balanceData ? (
+                            <div className="h-9 w-40 rounded bg-white/20 animate-pulse mb-3" />
+                        ) : (
+                            <p className="text-[28px] font-extrabold leading-tight m-0 mb-3 tabular-nums">
+                                {formatCurrency(available, currency)}
+                            </p>
+                        )}
+                        <div className="flex items-center justify-between text-[11px] opacity-90">
+                            <div>
+                                <p className="m-0 opacity-75">En reserva</p>
+                                <p className="m-0 font-bold tabular-nums">
+                                    {formatCurrency(holds, currency)}
+                                </p>
+                            </div>
+                            <div className="text-right">
+                                <p className="m-0 opacity-75">Total</p>
+                                <p className="m-0 font-bold tabular-nums">
+                                    {formatCurrency(clp?.balance ?? "0", currency)}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Quick actions — disabled until deposit/withdraw endpoints land */}
+                    <div className="grid grid-cols-2 gap-2 mt-3">
+                        <button
+                            type="button"
+                            disabled
+                            className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold bg-surface-solid text-muted opacity-60 cursor-not-allowed"
+                            aria-label="Recargar saldo (próximamente)"
+                            title="Próximamente"
+                        >
+                            <Plus className="size-3.5" />
+                            Recargar
+                        </button>
+                        <button
+                            type="button"
+                            disabled
+                            className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold bg-surface-solid text-muted opacity-60 cursor-not-allowed"
+                            aria-label="Retirar saldo (próximamente)"
+                            title="Próximamente"
+                        >
+                            <ArrowUpFromSquare className="size-3.5" />
+                            Retirar
+                        </button>
+                    </div>
+                </div>
+
+                {/* Recent movements */}
+                <div
+                    className="px-5 pt-2 pb-2 shrink-0 flex items-center justify-between"
+                    style={{ borderTop: "1px solid var(--border)" }}
+                >
+                    <p className="text-[11px] font-bold uppercase tracking-wider m-0" style={{ color: "var(--muted)" }}>
+                        Últimos movimientos
+                    </p>
+                </div>
+
+                <ScrollShadow className="flex-1 overflow-y-auto">
+                    {txLoading && !txData ? (
+                        <div className="flex flex-col gap-0 py-2">
+                            {[...Array(4)].map((_, i) => (
+                                <div key={i} className="flex items-center gap-3 px-5 py-3 animate-pulse">
+                                    <div
+                                        className="w-9 h-9 rounded-full shrink-0"
+                                        style={{ backgroundColor: "var(--surface)" }}
+                                    />
+                                    <div className="flex-1 space-y-2">
+                                        <div
+                                            className="h-3 rounded w-2/5"
+                                            style={{ backgroundColor: "var(--surface)" }}
+                                        />
+                                        <div
+                                            className="h-2.5 rounded w-1/4"
+                                            style={{ backgroundColor: "var(--surface)" }}
+                                        />
+                                    </div>
+                                    <div
+                                        className="h-3 rounded w-16 shrink-0"
+                                        style={{ backgroundColor: "var(--surface)" }}
+                                    />
+                                </div>
+                            ))}
+                        </div>
+                    ) : transactions.length === 0 ? (
+                        <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
+                            <div
+                                className="w-14 h-14 rounded-full flex items-center justify-center mb-3"
+                                style={{ backgroundColor: "var(--surface)" }}
+                            >
+                                <CreditCard
+                                    style={{ width: 22, height: 22, color: "var(--muted)", opacity: 0.4 }}
+                                />
+                            </div>
+                            <p className="text-sm font-semibold m-0" style={{ color: "var(--foreground)" }}>
+                                Aún no tienes movimientos
+                            </p>
+                            <p className="text-xs mt-1 m-0" style={{ color: "var(--muted)" }}>
+                                Tus transacciones aparecerán aquí.
+                            </p>
+                        </div>
+                    ) : (
+                        <div className="pb-2">
+                            {transactions.map((tx) => (
+                                <TransactionRow key={tx.id} tx={tx} />
+                            ))}
+                        </div>
+                    )}
+                </ScrollShadow>
+
+                {/* Footer */}
+                <div
+                    className="px-4 py-3 shrink-0"
+                    style={{ borderTop: "1px solid var(--border)" }}
+                >
+                    <Link
+                        href="/wallet"
+                        onClick={onClose}
+                        className="flex items-center justify-center gap-1.5 py-2 rounded-xl text-[12px] font-semibold transition-colors"
+                        style={{ color: "var(--accent)" }}
+                    >
+                        Ver historial completo →
+                    </Link>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/features/wallet/BalanceSidebar/index.ts
+++ b/features/wallet/BalanceSidebar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BalanceSidebar";

--- a/features/wallet/shared.ts
+++ b/features/wallet/shared.ts
@@ -1,0 +1,74 @@
+import type { WalletAccount, WalletTxKind } from "@/lib/types/wallet";
+
+// ── Spanish labels per transaction kind ──
+
+export const WALLET_KIND_LABELS: Record<WalletTxKind, string> = {
+    DEPOSIT: "Recarga",
+    WITHDRAWAL: "Retiro",
+    SALE_PROCEEDS: "Venta cobrada",
+    PURCHASE_DEBIT: "Compra",
+    AUCTION_HOLD: "Reserva subasta",
+    AUCTION_RELEASE: "Reserva liberada",
+    AUCTION_WIN: "Subasta ganada",
+    RAFFLE_ENTRY: "Ticket rifa",
+    RAFFLE_PRIZE: "Premio rifa",
+    REFERRAL_REWARD: "Recompensa referido",
+    TIP: "Propina",
+    REFUND: "Devolución",
+    FEE: "Comisión",
+    MANUAL_ADJUST: "Ajuste",
+};
+
+export function labelForKind(kind: string): string {
+    return (WALLET_KIND_LABELS as Record<string, string>)[kind] ?? kind;
+}
+
+// ── Account pickers ──
+
+/** Returns the AVAILABLE CLP account if the user has one. */
+export function pickAvailableCLP(accounts: WalletAccount[] | undefined): WalletAccount | undefined {
+    if (!accounts) return undefined;
+    return accounts.find((a) => a.currency === "CLP" && a.account_type === "AVAILABLE");
+}
+
+/**
+ * Aggregates balances grouped by currency — currently only CLP is shown,
+ * but this keeps the door open for multi-currency without refactors.
+ */
+export interface CurrencyGroup {
+    currency: string;
+    available: string;
+    holds: string;
+    total: string;
+}
+
+export function groupByCurrency(accounts: WalletAccount[] | undefined): CurrencyGroup[] {
+    if (!accounts || accounts.length === 0) return [];
+    const map = new Map<string, { available: number; holds: number; total: number }>();
+    for (const a of accounts) {
+        const entry = map.get(a.currency) ?? { available: 0, holds: 0, total: 0 };
+        const available = parseFloat(a.available || "0") || 0;
+        const holds = parseFloat(a.holds_active || "0") || 0;
+        const balance = parseFloat(a.balance || "0") || 0;
+
+        if (a.account_type === "AVAILABLE") {
+            entry.available += available;
+            entry.holds += holds;
+            entry.total += balance;
+        } else if (a.account_type === "PROMO") {
+            entry.available += available;
+            entry.total += balance;
+        } else {
+            // PENDING_IN / PENDING_OUT — surface in holds so the "reservado" figure stays meaningful
+            entry.holds += balance;
+            entry.total += balance;
+        }
+        map.set(a.currency, entry);
+    }
+    return Array.from(map.entries()).map(([currency, v]) => ({
+        currency,
+        available: String(v.available),
+        holds: String(v.holds),
+        total: String(v.total),
+    }));
+}

--- a/lib/api/wallet.ts
+++ b/lib/api/wallet.ts
@@ -1,0 +1,54 @@
+import { apiFetch } from "./client";
+import type { ApiResponse } from "@/lib/types/api";
+import type {
+    BalanceResponse,
+    TransactionsResponse,
+    PayoutsResponse,
+    TransactionsParams,
+} from "@/lib/types/wallet";
+
+// ── Balance ──
+
+export async function getBalance(token?: string): Promise<BalanceResponse> {
+    const res = await apiFetch<ApiResponse<BalanceResponse>>("/wallet/balance", undefined, {
+        cache: "no-store",
+        token,
+    });
+    const data = res?.data ?? res;
+    const accounts = Array.isArray(data?.accounts) ? data.accounts : [];
+    return { accounts };
+}
+
+// ── Transactions (keyset pagination) ──
+
+export async function getTransactions(
+    params?: TransactionsParams,
+    token?: string,
+): Promise<TransactionsResponse> {
+    const queryParams: Record<string, string | number | boolean | undefined> = {};
+    if (params?.limit !== undefined) queryParams.limit = params.limit;
+    if (params?.before !== undefined) queryParams.before = params.before;
+
+    const res = await apiFetch<ApiResponse<TransactionsResponse>>(
+        "/wallet/transactions",
+        queryParams,
+        { cache: "no-store", token },
+    );
+    const data = res?.data ?? res;
+    return {
+        limit: data?.limit ?? params?.limit ?? 20,
+        next_before: data?.next_before ?? 0,
+        transactions: Array.isArray(data?.transactions) ? data.transactions : [],
+    };
+}
+
+// ── Payouts (stubbed for MVP read-only — no UI yet) ──
+
+export async function getPayouts(token?: string): Promise<PayoutsResponse> {
+    const res = await apiFetch<ApiResponse<PayoutsResponse>>("/wallet/payouts", undefined, {
+        cache: "no-store",
+        token,
+    });
+    const data = res?.data ?? res;
+    return { payouts: Array.isArray(data?.payouts) ? data.payouts : [] };
+}

--- a/lib/hooks/use-wallet.ts
+++ b/lib/hooks/use-wallet.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
+import * as walletApi from "@/lib/api/wallet";
+import { useAuthStore } from "@/lib/stores/auth-store";
+import type { TransactionsParams, TransactionsResponse } from "@/lib/types/wallet";
+
+// ── Balance ──
+// Polls every 30s while the page/tab is focused, matching the reference b1tcore UX.
+
+export function useBalance() {
+    const accessToken = useAuthStore((s) => s.accessToken);
+    const isAuthenticated = !!accessToken;
+    return useQuery({
+        queryKey: ["wallet", "balance"],
+        queryFn: () => walletApi.getBalance(),
+        enabled: isAuthenticated,
+        refetchInterval: 30_000,
+        refetchOnWindowFocus: true,
+        staleTime: 10_000,
+    });
+}
+
+// ── Transactions (single page) ──
+
+export function useTransactions(params?: TransactionsParams) {
+    const accessToken = useAuthStore((s) => s.accessToken);
+    const isAuthenticated = !!accessToken;
+    return useQuery({
+        queryKey: ["wallet", "transactions", params ?? {}],
+        queryFn: () => walletApi.getTransactions(params),
+        enabled: isAuthenticated,
+    });
+}
+
+// ── Transactions (infinite / keyset pagination) ──
+
+export function useInfiniteTransactions(limit = 20) {
+    const accessToken = useAuthStore((s) => s.accessToken);
+    const isAuthenticated = !!accessToken;
+    return useInfiniteQuery({
+        queryKey: ["wallet", "transactions", "infinite", { limit }] as const,
+        queryFn: ({ pageParam }: { pageParam: number | undefined }) =>
+            walletApi.getTransactions({ limit, before: pageParam }),
+        initialPageParam: undefined as number | undefined,
+        getNextPageParam: (lastPage: TransactionsResponse): number | undefined => {
+            // next_before === 0 means "no more"
+            if (!lastPage?.next_before || lastPage.next_before <= 0) return undefined;
+            if (!lastPage.transactions || lastPage.transactions.length < limit) return undefined;
+            return lastPage.next_before;
+        },
+        enabled: isAuthenticated,
+    });
+}
+
+// ── Payouts (stub) ──
+
+export function usePayouts() {
+    const accessToken = useAuthStore((s) => s.accessToken);
+    const isAuthenticated = !!accessToken;
+    return useQuery({
+        queryKey: ["wallet", "payouts"],
+        queryFn: () => walletApi.getPayouts(),
+        enabled: isAuthenticated,
+    });
+}

--- a/lib/stores/ui-store.ts
+++ b/lib/stores/ui-store.ts
@@ -20,6 +20,9 @@ interface UIState {
   closeNotificationSidebar: () => void;
   notificationUnreadCount: number;
   setNotificationUnreadCount: (n: number) => void;
+  balanceSidebarOpen: boolean;
+  openBalanceSidebar: () => void;
+  closeBalanceSidebar: () => void;
 }
 
 export const useUIStore = create<UIState>()((set) => ({
@@ -40,4 +43,7 @@ export const useUIStore = create<UIState>()((set) => ({
   closeNotificationSidebar: () => set({ notificationSidebarOpen: false }),
   notificationUnreadCount: 0,
   setNotificationUnreadCount: (n) => set({ notificationUnreadCount: n }),
+  balanceSidebarOpen: false,
+  openBalanceSidebar: () => set({ balanceSidebarOpen: true }),
+  closeBalanceSidebar: () => set({ balanceSidebarOpen: false }),
 }));

--- a/lib/types/wallet.ts
+++ b/lib/types/wallet.ts
@@ -1,0 +1,64 @@
+// ── Wallet types ──
+//
+// Amounts are preserved as strings (NUMERIC(18,4) on the backend) to avoid
+// float precision loss. UI layer should format via Intl.NumberFormat.
+
+export type WalletAccountType = "AVAILABLE" | "PENDING_IN" | "PENDING_OUT" | "PROMO";
+
+export interface WalletAccount {
+    id: string;
+    account_type: WalletAccountType;
+    currency: string;
+    balance: string;
+    holds_active: string;
+    available: string;
+    updated_at: string;
+}
+
+export type WalletTxKind =
+    | "DEPOSIT"
+    | "WITHDRAWAL"
+    | "SALE_PROCEEDS"
+    | "PURCHASE_DEBIT"
+    | "AUCTION_HOLD"
+    | "AUCTION_RELEASE"
+    | "AUCTION_WIN"
+    | "RAFFLE_ENTRY"
+    | "RAFFLE_PRIZE"
+    | "REFERRAL_REWARD"
+    | "TIP"
+    | "REFUND"
+    | "FEE"
+    | "MANUAL_ADJUST";
+
+export interface WalletTransaction {
+    id: string;
+    account_id: string;
+    kind: WalletTxKind;
+    amount: string;              // signed string, e.g. "-10000.0000" or "50000.0000"
+    balance_after: string;
+    currency: string;
+    reference_type: string;
+    reference_id: string;
+    metadata: string;            // JSON string — parse lazily in UI if needed
+    created_at: string;
+}
+
+export interface BalanceResponse {
+    accounts: WalletAccount[];
+}
+
+export interface TransactionsResponse {
+    limit: number;
+    next_before: number;
+    transactions: WalletTransaction[];
+}
+
+export interface PayoutsResponse {
+    payouts: unknown[];
+}
+
+export interface TransactionsParams {
+    limit?: number;
+    before?: number;
+}

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -62,3 +62,62 @@ export function sanitizeHref(url: string | undefined | null): string | null {
     } catch { /* invalid URL */ }
     return null;
 }
+
+// ── Currency / wallet helpers ──
+
+/**
+ * Formats a monetary value into an es-CL currency string.
+ * Accepts either string (backend NUMERIC, preferred) or number.
+ * CLP renders without decimals; every other currency uses 2 decimals.
+ */
+export function formatCurrency(amount: string | number, currency = "CLP"): string {
+    const n = typeof amount === "string" ? parseFloat(amount) : amount;
+    const safe = Number.isFinite(n) ? n : 0;
+    return new Intl.NumberFormat("es-CL", {
+        style: "currency",
+        currency,
+        minimumFractionDigits: currency === "CLP" ? 0 : 2,
+        maximumFractionDigits: currency === "CLP" ? 0 : 2,
+    }).format(safe);
+}
+
+/**
+ * Same as formatCurrency, but preserves the sign explicitly as "+…" or "−…".
+ * Useful for transaction rows where direction matters visually.
+ */
+export function formatSignedCurrency(amount: string | number, currency = "CLP"): string {
+    const n = typeof amount === "string" ? parseFloat(amount) : amount;
+    const safe = Number.isFinite(n) ? n : 0;
+    const abs = Math.abs(safe);
+    const formatted = formatCurrency(abs, currency);
+    if (safe > 0) return `+${formatted}`;
+    if (safe < 0) return `−${formatted}`;
+    return formatted;
+}
+
+/** Compact relative time (Spanish). Short form for dense UIs (sidebars/tables). */
+export function formatRelativeTime(iso: string): string {
+    if (!iso) return "";
+    const diff = Date.now() - new Date(iso).getTime();
+    const min = Math.floor(diff / 60_000);
+    if (min < 1) return "ahora";
+    if (min < 60) return `${min}m`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h`;
+    const days = Math.floor(hr / 24);
+    if (days < 7) return `${days}d`;
+    return new Date(iso).toLocaleDateString("es-CL");
+}
+
+/** True when a wallet transaction kind represents a credit (money in). */
+export function isCreditTx(kind: string): boolean {
+    return [
+        "DEPOSIT",
+        "SALE_PROCEEDS",
+        "AUCTION_RELEASE",
+        "RAFFLE_PRIZE",
+        "REFERRAL_REWARD",
+        "TIP",
+        "REFUND",
+    ].includes(kind);
+}


### PR DESCRIPTION
## Resumen

Primera iteración del wallet en el frontend web — **read-only**. Lee los 3 endpoints de wallet que ya están vivos en producción (`/api/v1/wallet/balance`, `/api/v1/wallet/transactions`, `/api/v1/wallet/payouts`), sin mutaciones. Depósitos, retiros, holds y payouts llegan en PRs posteriores cuando aterrice `rankeao-go-payments`.

## Qué agrega

### Capa de datos (`lib/`)
- **`lib/types/wallet.ts`** — `WalletAccount`, `WalletTransaction`, `WalletTxKind` (14 valores del enum), `BalanceResponse`, `TransactionsResponse`, `PayoutsResponse`. Los montos se mantienen como `string` para no perder precisión del `NUMERIC(18,4)` del backend.
- **`lib/api/wallet.ts`** — `getBalance`, `getTransactions({limit, before})`, `getPayouts` siguiendo el patrón `apiFetch` + `ApiResponse<T>` de `marketplace.ts`.
- **`lib/hooks/use-wallet.ts`** — `useBalance` (con `refetchInterval: 30_000` replicando el UX de b1tcore), `useTransactions` por página y `useInfiniteTransactions` con `getNextPageParam` que lee `next_before` del backend.
- **`lib/utils/format.ts`** — extendido con `formatCurrency`, `formatSignedCurrency` (signo explícito `+/−`), `formatRelativeTime`, `isCreditTx`. Sin duplicar `timeAgo` existente.
- **`lib/stores/ui-store.ts`** — agrega `balanceSidebarOpen` + `open/closeBalanceSidebar` sin tocar el resto del store.

### UI (`features/wallet/`)
- **`BalanceDisplay`** — pill compacta para el navbar con dos variantes:
  - Desktop: `$40.000` + ícono `CreditCard` dentro de un círculo accent, 36px de alto, HeroUI-styled
  - Mobile: icon-only 40×40 que encaja con los otros botones del topbar
  - No renderiza nada si el usuario no está autenticado. Click → abre el sidebar.
- **`BalanceSidebar`** — drawer lateral derecho (420px), gradiente accent en la card principal con disponible / reserva / total, lista de últimos 4 movimientos con color semáforo (verde `#00b24b` créditos, rojo `#f63d00` débitos) y signo explícito. Focus trap + `Escape` + lock de `body.overflow`, igual que `NotificationSidebar`.
- **`features/wallet/shared.ts`** — mapa de `WalletTxKind → label ES` (Recarga, Retiro, Venta cobrada, Compra, Reserva subasta, etc.) y helpers `pickAvailableCLP` / `groupByCurrency`.

### Página de historial
- **`app/(app)/wallet/page.tsx`** + **`WalletClient.tsx`** — protegida por `AuthGuard`, con:
  - `PageHero` + dos CTAs disabled (Recargar/Retirar) marcados "Próximamente"
  - Cards de saldo por moneda (hoy solo CLP; ya está preparado para multi-currency via `groupByCurrency`)
  - Chips de filtro por kind (se muestran solo cuando hay >1 kind distinto en las transacciones cargadas)
  - Tabla de movimientos con `grid` responsive (columna "Saldo resultante" oculta en mobile)
  - Paginación keyset con `useInfiniteTransactions` + botón "Cargar más" que respeta `next_before === 0` del backend
  - Empty state específico (usuario sin movimientos) vs empty por filtro

### Integración del navbar
- `components/layout/Navbar/Navbar.tsx`:
  - `BalanceDisplay variant="mobile"` insertado antes de la campana móvil
  - `BalanceDisplay variant="desktop"` insertado antes de la campana desktop
  - `BalanceSidebar` montado como overlay al final del `<header>` (solo cuando `isAuthenticated && balanceSidebarOpen` → no paga el costo si no se usa)
  - Ambos componentes vía `dynamic(() => import(...), { ssr: false })` para evitar hydration mismatch por el estado del auth-store persistido

## Validación

### Endpoints verificados contra prod (`https://api.rankeao.cl`)

Login con `alexandersantisarellano@gmail.com`:

```
GET /wallet/balance
  → { accounts: [{ account_type: "AVAILABLE", currency: "CLP",
      balance: "40000.0000", available: "40000.0000", holds_active: "0", ... }] }

GET /wallet/transactions?limit=4
  → { limit: 4, next_before: 0, transactions: [
      { kind: "PURCHASE_DEBIT", amount: "-10000.0000", balance_after: "40000.0000", ... },
      { kind: "DEPOSIT", amount: "50000.0000", balance_after: "50000.0000", ... }
    ]}

GET /wallet/payouts
  → { payouts: [] }
```

Las formas coinciden 1:1 con los tipos definidos en `lib/types/wallet.ts`.

### Build / Lint
- `npx tsc --noEmit` — sin errores en los archivos nuevos del wallet (los errores pre-existentes en `features/stories/**` y `features/social/**` son independientes de este PR).
- `npx eslint features/wallet lib/api/wallet.ts lib/hooks/use-wallet.ts lib/types/wallet.ts 'app/(app)/wallet'` — **0 errores, 0 warnings**.
- `npm run build` — compilación Turbopack OK (`Compiled successfully in 4.0s`, TypeScript OK). El único prerender error (`/login` por `useSearchParams` sin Suspense) existe también en `main` sin estos cambios.

## Fuera de scope

- Depósitos (`/wallet/holds`, `/wallet/holds/:id/capture`) — esperando flujo de `rankeao-go-payments`
- Retiros / payouts UI — backend scaffold, no UI
- Admin wallet
- Wiring contra marketplace orders (hoy los txs de marketplace ya aparecen en el historial; falta hacer que el checkout use wallet-first)

## Test plan

- [ ] `npm install && npm run dev`
- [ ] Login con `alexandersantisarellano@gmail.com` / `Alexitic0.`
- [ ] Verificar pill `$40.000` en el navbar (desktop y mobile)
- [ ] Click → abre sidebar con 2 transacciones y el footer "Ver historial completo →"
- [ ] Click en el footer → navega a `/wallet`, muestra card grande y tabla con las mismas 2 transacciones
- [ ] Logout → pill desaparece sin warnings en consola
- [ ] Escape / click en backdrop / botón X → cierran el sidebar
- [ ] DevTools > Network: el refetch de balance ocurre cada ~30s