### PR TITLE
feat(wallet): modales de recarga y retiro con tabs en /wallet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,10 @@ NEXT_PUBLIC_API_URL=https://api.rankeao.cl/api/v1
 # Invite al server de Discord de Rankeao — usado por el modal de vinculacion
 # en /config. Si no esta seteado, el boton "Abrir Discord" no se muestra.
 NEXT_PUBLIC_DISCORD_INVITE_URL=
+
+# Feature flag: habilita el wallet para BUYERS (recarga de saldo via
+# DepositModal y boton "Recargar" en la sidebar). Con el pivot a Transbank
+# directo queda en "false" por defecto: las compras se cobran al pagar y el
+# wallet pasa a ser usado sólo para payouts de sellers. Ponerlo en "true"
+# para reactivar la recarga en Vercel si se revierte la decisión.
+NEXT_PUBLIC_BUYER_WALLET_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -149,3 +149,11 @@ Archivos clave:
 - `src/app/login/LoginForm.tsx`
 - `src/app/register/RegisterForm.tsx`
 - `src/components/Navbar.tsx`
+
+## 8. Feature Flags
+
+Definidos en `lib/flags.ts`. Se leen desde `NEXT_PUBLIC_*` en build time.
+
+- `NEXT_PUBLIC_BUYER_WALLET_ENABLED` (default: `"false"`)
+  - `true` → muestra el `DepositModal` y el boton "Recargar" en la sidebar/pagina de wallet.
+  - `false` (actual) → el wallet de compradores queda oculto. Las compras se cobran directo via Transbank al pagar en el marketplace. El wallet pasa a ser usado solo para payouts de sellers (detectado via `useIsSeller`, que consulta `GET /marketplace/seller/me`).

--- a/app/(app)/wallet/WalletClient.tsx
+++ b/app/(app)/wallet/WalletClient.tsx
@@ -11,6 +11,8 @@ import {
     useInfiniteTransactions,
     usePayouts,
 } from "@/lib/hooks/use-wallet";
+import { useIsSeller } from "@/lib/hooks/use-is-seller";
+import { BUYER_WALLET_ENABLED } from "@/lib/flags";
 import {
     groupByCurrency,
     labelForKind,
@@ -310,9 +312,26 @@ type WalletTab = "transactions" | "payouts";
 
 function WalletContent() {
     const [kindFilter, setKindFilter] = useState<string>("ALL");
-    const [activeTab, setActiveTab] = useState<WalletTab>("transactions");
+    const [rawActiveTab, setActiveTab] = useState<WalletTab>("transactions");
     const openDeposit = useUIStore((s) => s.openDepositModal);
     const openPayout = useUIStore((s) => s.openPayoutModal);
+    const { isSeller } = useIsSeller();
+
+    const showDepositCTA = BUYER_WALLET_ENABLED;
+    const showPayoutCTA = isSeller;
+    const tabs = useMemo(() => {
+        const base: Array<{ key: WalletTab; label: string }> = [
+            { key: "transactions", label: "Transacciones" },
+        ];
+        if (isSeller) base.push({ key: "payouts", label: "Retiros" });
+        return base;
+    }, [isSeller]);
+
+    // Si el user no es seller pero el estado local quedó en "payouts",
+    // forzamos la tab visible a "transactions" — sin tocar setState en
+    // un effect (para evitar cascading renders).
+    const activeTab: WalletTab =
+        rawActiveTab === "payouts" && !isSeller ? "transactions" : rawActiveTab;
 
     const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
         useInfiniteTransactions(20);
@@ -342,65 +361,70 @@ function WalletContent() {
                 title="Mi wallet"
                 subtitle="Tu saldo disponible y el historial de movimientos en Rankeao."
                 action={
-                    <div className="hidden md:flex flex-col gap-2 min-w-[140px]">
-                        <Button
-                            size="sm"
-                            variant="primary"
-                            className="font-bold"
-                            aria-label="Recargar saldo"
-                            onPress={openDeposit}
-                        >
-                            <Plus className="size-3.5 mr-1.5" />
-                            Recargar
-                        </Button>
-                        <Button
-                            size="sm"
-                            variant="tertiary"
-                            className="font-bold"
-                            aria-label="Retirar saldo"
-                            onPress={openPayout}
-                        >
-                            <ArrowUpFromSquare className="size-3.5 mr-1.5" />
-                            Retirar
-                        </Button>
-                    </div>
+                    showDepositCTA || showPayoutCTA ? (
+                        <div className="hidden md:flex flex-col gap-2 min-w-[140px]">
+                            {showDepositCTA && (
+                                <Button
+                                    size="sm"
+                                    variant="primary"
+                                    className="font-bold"
+                                    aria-label="Recargar saldo"
+                                    onPress={openDeposit}
+                                >
+                                    <Plus className="size-3.5 mr-1.5" />
+                                    Recargar
+                                </Button>
+                            )}
+                            {showPayoutCTA && (
+                                <Button
+                                    size="sm"
+                                    variant="tertiary"
+                                    className="font-bold"
+                                    aria-label="Retirar saldo"
+                                    onPress={openPayout}
+                                >
+                                    <ArrowUpFromSquare className="size-3.5 mr-1.5" />
+                                    Retirar
+                                </Button>
+                            )}
+                        </div>
+                    ) : undefined
                 }
             />
 
             <BalanceCards />
 
-            {/* Tabs */}
-            <div
-                role="tablist"
-                aria-label="Secciones de wallet"
-                className="mx-4 lg:mx-6 mb-3 flex gap-2"
-            >
-                {([
-                    { key: "transactions", label: "Transacciones" },
-                    { key: "payouts", label: "Retiros" },
-                ] as const).map((tab) => {
-                    const isActive = activeTab === tab.key;
-                    return (
-                        <button
-                            key={tab.key}
-                            role="tab"
-                            type="button"
-                            aria-selected={isActive}
-                            onClick={() => setActiveTab(tab.key)}
-                            className="px-4 py-2 rounded-full text-[13px] font-semibold whitespace-nowrap cursor-pointer transition-colors"
-                            style={{
-                                backgroundColor: isActive ? "var(--foreground)" : "var(--surface-solid)",
-                                color: isActive ? "var(--background)" : "var(--muted)",
-                                border: isActive ? "1px solid transparent" : "1px solid var(--border)",
-                            }}
-                        >
-                            {tab.label}
-                        </button>
-                    );
-                })}
-            </div>
+            {/* Tabs — sólo se renderiza la barra si hay más de una tab (ej: seller) */}
+            {tabs.length > 1 && (
+                <div
+                    role="tablist"
+                    aria-label="Secciones de wallet"
+                    className="mx-4 lg:mx-6 mb-3 flex gap-2"
+                >
+                    {tabs.map((tab) => {
+                        const isActive = activeTab === tab.key;
+                        return (
+                            <button
+                                key={tab.key}
+                                role="tab"
+                                type="button"
+                                aria-selected={isActive}
+                                onClick={() => setActiveTab(tab.key)}
+                                className="px-4 py-2 rounded-full text-[13px] font-semibold whitespace-nowrap cursor-pointer transition-colors"
+                                style={{
+                                    backgroundColor: isActive ? "var(--foreground)" : "var(--surface-solid)",
+                                    color: isActive ? "var(--background)" : "var(--muted)",
+                                    border: isActive ? "1px solid transparent" : "1px solid var(--border)",
+                                }}
+                            >
+                                {tab.label}
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
 
-            {activeTab === "payouts" && <PayoutsPanel />}
+            {activeTab === "payouts" && isSeller && <PayoutsPanel />}
             {activeTab === "transactions" && <TransactionsPanel
                 allTxs={allTxs}
                 filtered={filtered}
@@ -413,6 +437,7 @@ function WalletContent() {
                 isFetchingNextPage={isFetchingNextPage}
                 fetchNextPage={fetchNextPage}
                 openDeposit={openDeposit}
+                showDepositCTA={showDepositCTA}
             />}
         </div>
     );
@@ -432,6 +457,7 @@ interface TransactionsPanelProps {
     isFetchingNextPage: boolean;
     fetchNextPage: () => void;
     openDeposit: () => void;
+    showDepositCTA: boolean;
 }
 
 function TransactionsPanel({
@@ -446,6 +472,7 @@ function TransactionsPanel({
     isFetchingNextPage,
     fetchNextPage,
     openDeposit,
+    showDepositCTA,
 }: TransactionsPanelProps) {
     return (
         <>
@@ -538,14 +565,16 @@ function TransactionsPanel({
                             <p className="text-xs mt-1 mb-4" style={{ color: "var(--muted)" }}>
                                 Cuando recibas o gastes saldo aparecerá aquí.
                             </p>
-                            <Button
-                                size="sm"
-                                variant="primary"
-                                aria-label="Recargar saldo"
-                                onPress={openDeposit}
-                            >
-                                Recargar saldo
-                            </Button>
+                            {showDepositCTA && (
+                                <Button
+                                    size="sm"
+                                    variant="primary"
+                                    aria-label="Recargar saldo"
+                                    onPress={openDeposit}
+                                >
+                                    Recargar saldo
+                                </Button>
+                            )}
                         </div>
                     ) : filtered.length === 0 ? (
                         <div className="flex flex-col items-center justify-center py-12 px-6 text-center">

--- a/app/(app)/wallet/WalletClient.tsx
+++ b/app/(app)/wallet/WalletClient.tsx
@@ -6,15 +6,25 @@ import { Button } from "@heroui/react/button";
 
 import PageHero from "@/components/ui/PageHero";
 import { AuthGuard } from "@/components/ui/AuthGuard/AuthGuard";
-import { useBalance, useInfiniteTransactions } from "@/lib/hooks/use-wallet";
-import { groupByCurrency, labelForKind } from "@/features/wallet/shared";
+import {
+    useBalance,
+    useInfiniteTransactions,
+    usePayouts,
+} from "@/lib/hooks/use-wallet";
+import {
+    groupByCurrency,
+    labelForKind,
+    labelForPayoutStatus,
+    tonalStyleForPayoutStatus,
+} from "@/features/wallet/shared";
 import {
     formatCurrency,
     formatSignedCurrency,
     isCreditTx,
     timeAgo,
 } from "@/lib/utils/format";
-import type { WalletTransaction } from "@/lib/types/wallet";
+import { useUIStore } from "@/lib/stores/ui-store";
+import type { WalletTransaction, WalletPayout } from "@/lib/types/wallet";
 
 // ── Balance cards ──
 
@@ -147,10 +157,163 @@ function TxDesktopRow({ tx }: { tx: WalletTransaction }) {
     );
 }
 
+// ── Payout row ──
+
+function PayoutRow({ payout }: { payout: WalletPayout }) {
+    const currency = payout.currency || "CLP";
+    const tone = tonalStyleForPayoutStatus(payout.status);
+    const createdAt = payout.created_at
+        ? new Date(payout.created_at).toLocaleDateString("es-CL", {
+              day: "numeric",
+              month: "short",
+              year: "numeric",
+          })
+        : "—";
+    const resolvedAt = payout.resolved_at
+        ? new Date(payout.resolved_at).toLocaleDateString("es-CL", {
+              day: "numeric",
+              month: "short",
+              year: "numeric",
+          })
+        : null;
+
+    return (
+        <div
+            className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-4 px-5 py-3 border-b"
+            style={{ borderColor: "var(--border)" }}
+        >
+            <div className="min-w-0">
+                <p className="text-[13px] font-semibold text-foreground m-0">
+                    Retiro · {createdAt}
+                </p>
+                {payout.rejection_reason && (
+                    <p
+                        className="text-[11px] m-0 truncate"
+                        style={{ color: "#b53000" }}
+                        title={payout.rejection_reason}
+                    >
+                        Motivo: {payout.rejection_reason}
+                    </p>
+                )}
+                {!payout.rejection_reason && resolvedAt && (
+                    <p className="text-[11px] m-0" style={{ color: "var(--muted)" }}>
+                        Resuelto: {resolvedAt}
+                    </p>
+                )}
+            </div>
+            <p
+                className="text-[13px] font-bold tabular-nums m-0 text-right"
+                style={{ color: "var(--foreground)" }}
+            >
+                {formatCurrency(payout.amount, currency)}
+            </p>
+            <span
+                className="text-[11px] font-semibold px-2 py-0.5 rounded-full whitespace-nowrap"
+                style={{ backgroundColor: tone.bg, color: tone.color }}
+            >
+                {labelForPayoutStatus(payout.status)}
+            </span>
+            <span aria-hidden="true" className="hidden md:inline-block w-4" />
+        </div>
+    );
+}
+
+// ── Payouts tab ──
+
+function PayoutsPanel() {
+    const { data, isLoading } = usePayouts();
+    const payouts = data?.payouts ?? [];
+
+    return (
+        <div className="mx-4 lg:mx-6 mb-10">
+            <div
+                className="rounded-2xl overflow-hidden"
+                style={{
+                    backgroundColor: "var(--surface-solid)",
+                    border: "1px solid var(--border)",
+                }}
+            >
+                <div
+                    className="grid grid-cols-[1fr_auto_auto_auto] gap-4 px-5 py-3 text-[11px] font-bold uppercase tracking-wider"
+                    style={{
+                        color: "var(--muted)",
+                        borderBottom: "1px solid var(--border)",
+                    }}
+                >
+                    <span>Solicitud</span>
+                    <span className="text-right">Monto</span>
+                    <span className="text-right">Estado</span>
+                    <span aria-hidden="true" className="hidden md:inline-block w-4" />
+                </div>
+
+                {isLoading && payouts.length === 0 ? (
+                    <div>
+                        {[...Array(3)].map((_, i) => (
+                            <div
+                                key={i}
+                                className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-4 px-5 py-3 animate-pulse border-b"
+                                style={{ borderColor: "var(--border)" }}
+                            >
+                                <div
+                                    className="h-3 w-2/5 rounded"
+                                    style={{ backgroundColor: "var(--surface)" }}
+                                />
+                                <div
+                                    className="h-3 w-20 rounded"
+                                    style={{ backgroundColor: "var(--surface)" }}
+                                />
+                                <div
+                                    className="h-3 w-16 rounded"
+                                    style={{ backgroundColor: "var(--surface)" }}
+                                />
+                                <span className="hidden md:inline-block w-4" />
+                            </div>
+                        ))}
+                    </div>
+                ) : payouts.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+                        <div
+                            className="w-16 h-16 rounded-full flex items-center justify-center mb-4"
+                            style={{ backgroundColor: "var(--surface)" }}
+                        >
+                            <ArrowUpFromSquare
+                                style={{
+                                    width: 26,
+                                    height: 26,
+                                    color: "var(--muted)",
+                                    opacity: 0.4,
+                                }}
+                            />
+                        </div>
+                        <p className="text-sm font-semibold m-0" style={{ color: "var(--foreground)" }}>
+                            Aún no tienes solicitudes de retiro
+                        </p>
+                        <p className="text-xs mt-1 mb-0" style={{ color: "var(--muted)" }}>
+                            Cuando solicites un retiro aparecerá aquí con su estado.
+                        </p>
+                    </div>
+                ) : (
+                    <div>
+                        {payouts.map((p) => (
+                            <PayoutRow key={p.id} payout={p} />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
 // ── Main wallet page (behind AuthGuard) ──
+
+type WalletTab = "transactions" | "payouts";
 
 function WalletContent() {
     const [kindFilter, setKindFilter] = useState<string>("ALL");
+    const [activeTab, setActiveTab] = useState<WalletTab>("transactions");
+    const openDeposit = useUIStore((s) => s.openDepositModal);
+    const openPayout = useUIStore((s) => s.openPayoutModal);
+
     const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
         useInfiniteTransactions(20);
 
@@ -179,13 +342,13 @@ function WalletContent() {
                 title="Mi wallet"
                 subtitle="Tu saldo disponible y el historial de movimientos en Rankeao."
                 action={
-                    <div className="hidden md:flex flex-col gap-2 min-w-[140px]" title="Próximamente">
+                    <div className="hidden md:flex flex-col gap-2 min-w-[140px]">
                         <Button
                             size="sm"
                             variant="primary"
-                            isDisabled
                             className="font-bold"
-                            aria-label="Recargar saldo (próximamente)"
+                            aria-label="Recargar saldo"
+                            onPress={openDeposit}
                         >
                             <Plus className="size-3.5 mr-1.5" />
                             Recargar
@@ -193,9 +356,9 @@ function WalletContent() {
                         <Button
                             size="sm"
                             variant="tertiary"
-                            isDisabled
                             className="font-bold"
-                            aria-label="Retirar saldo (próximamente)"
+                            aria-label="Retirar saldo"
+                            onPress={openPayout}
                         >
                             <ArrowUpFromSquare className="size-3.5 mr-1.5" />
                             Retirar
@@ -206,6 +369,86 @@ function WalletContent() {
 
             <BalanceCards />
 
+            {/* Tabs */}
+            <div
+                role="tablist"
+                aria-label="Secciones de wallet"
+                className="mx-4 lg:mx-6 mb-3 flex gap-2"
+            >
+                {([
+                    { key: "transactions", label: "Transacciones" },
+                    { key: "payouts", label: "Retiros" },
+                ] as const).map((tab) => {
+                    const isActive = activeTab === tab.key;
+                    return (
+                        <button
+                            key={tab.key}
+                            role="tab"
+                            type="button"
+                            aria-selected={isActive}
+                            onClick={() => setActiveTab(tab.key)}
+                            className="px-4 py-2 rounded-full text-[13px] font-semibold whitespace-nowrap cursor-pointer transition-colors"
+                            style={{
+                                backgroundColor: isActive ? "var(--foreground)" : "var(--surface-solid)",
+                                color: isActive ? "var(--background)" : "var(--muted)",
+                                border: isActive ? "1px solid transparent" : "1px solid var(--border)",
+                            }}
+                        >
+                            {tab.label}
+                        </button>
+                    );
+                })}
+            </div>
+
+            {activeTab === "payouts" && <PayoutsPanel />}
+            {activeTab === "transactions" && <TransactionsPanel
+                allTxs={allTxs}
+                filtered={filtered}
+                kindFilter={kindFilter}
+                setKindFilter={setKindFilter}
+                availableKinds={availableKinds}
+                isLoading={isLoading}
+                emptyFirstLoad={emptyFirstLoad}
+                hasNextPage={!!hasNextPage}
+                isFetchingNextPage={isFetchingNextPage}
+                fetchNextPage={fetchNextPage}
+                openDeposit={openDeposit}
+            />}
+        </div>
+    );
+}
+
+// ── Transactions panel (extracted so Tabs can switch cleanly) ──
+
+interface TransactionsPanelProps {
+    allTxs: WalletTransaction[];
+    filtered: WalletTransaction[];
+    kindFilter: string;
+    setKindFilter: (k: string) => void;
+    availableKinds: string[];
+    isLoading: boolean;
+    emptyFirstLoad: boolean;
+    hasNextPage: boolean;
+    isFetchingNextPage: boolean;
+    fetchNextPage: () => void;
+    openDeposit: () => void;
+}
+
+function TransactionsPanel({
+    allTxs,
+    filtered,
+    kindFilter,
+    setKindFilter,
+    availableKinds,
+    isLoading,
+    emptyFirstLoad,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    openDeposit,
+}: TransactionsPanelProps) {
+    return (
+        <>
             {/* Filter chips */}
             {availableKinds.length > 1 && (
                 <div className="mx-4 lg:mx-6 mb-3 flex flex-wrap gap-2">
@@ -298,10 +541,10 @@ function WalletContent() {
                             <Button
                                 size="sm"
                                 variant="primary"
-                                isDisabled
-                                aria-label="Recargar saldo (próximamente)"
+                                aria-label="Recargar saldo"
+                                onPress={openDeposit}
                             >
-                                Recargar saldo (próximamente)
+                                Recargar saldo
                             </Button>
                         </div>
                     ) : filtered.length === 0 ? (
@@ -338,7 +581,7 @@ function WalletContent() {
                     </div>
                 )}
             </div>
-        </div>
+        </>
     );
 }
 

--- a/components/layout/AppShell/AppShell.tsx
+++ b/components/layout/AppShell/AppShell.tsx
@@ -5,11 +5,16 @@ import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
 import Sidebar from "@/components/layout/Sidebar";
 import BottomNav from "@/components/layout/BottomNav";
+import { BUYER_WALLET_ENABLED } from "@/lib/flags";
 
 const CreatePostModal = dynamic(() => import("@/features/social/CreatePostModal"), { ssr: false });
 const CreateDeckModal = dynamic(() => import("@/features/deck/CreateDeckModal"), { ssr: false });
 const CreateListingModal = dynamic(() => import("@/features/marketplace/CreateListingModal"), { ssr: false });
-const DepositModal = dynamic(() => import("@/features/wallet/DepositModal"), { ssr: false });
+// DepositModal sólo se carga cuando el wallet de buyers está habilitado.
+// Con el pivot a Transbank directo queda oculto por defecto — ver lib/flags.ts.
+const DepositModal = BUYER_WALLET_ENABLED
+    ? dynamic(() => import("@/features/wallet/DepositModal"), { ssr: false })
+    : null;
 const PayoutRequestModal = dynamic(() => import("@/features/wallet/PayoutRequestModal"), { ssr: false });
 const CreatePostFAB = dynamic(() => import("@/features/chat/ChatFAB"), { ssr: false });
 
@@ -51,7 +56,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             <SafeBoundary><CreatePostModal /></SafeBoundary>
             <SafeBoundary><CreateDeckModal /></SafeBoundary>
             <SafeBoundary><CreateListingModal /></SafeBoundary>
-            <SafeBoundary><DepositModal /></SafeBoundary>
+            {DepositModal && <SafeBoundary><DepositModal /></SafeBoundary>}
             <SafeBoundary><PayoutRequestModal /></SafeBoundary>
             {!isFixedLayout && <SafeBoundary><CreatePostFAB /></SafeBoundary>}
         </div>

--- a/components/layout/AppShell/AppShell.tsx
+++ b/components/layout/AppShell/AppShell.tsx
@@ -9,6 +9,8 @@ import BottomNav from "@/components/layout/BottomNav";
 const CreatePostModal = dynamic(() => import("@/features/social/CreatePostModal"), { ssr: false });
 const CreateDeckModal = dynamic(() => import("@/features/deck/CreateDeckModal"), { ssr: false });
 const CreateListingModal = dynamic(() => import("@/features/marketplace/CreateListingModal"), { ssr: false });
+const DepositModal = dynamic(() => import("@/features/wallet/DepositModal"), { ssr: false });
+const PayoutRequestModal = dynamic(() => import("@/features/wallet/PayoutRequestModal"), { ssr: false });
 const CreatePostFAB = dynamic(() => import("@/features/chat/ChatFAB"), { ssr: false });
 
 const fullWidthPages = ["/login", "/register", "/forgot-password", "/reset-password", "/verify-email", "/terminos", "/privacidad", "/cookies"];
@@ -49,6 +51,8 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             <SafeBoundary><CreatePostModal /></SafeBoundary>
             <SafeBoundary><CreateDeckModal /></SafeBoundary>
             <SafeBoundary><CreateListingModal /></SafeBoundary>
+            <SafeBoundary><DepositModal /></SafeBoundary>
+            <SafeBoundary><PayoutRequestModal /></SafeBoundary>
             {!isFixedLayout && <SafeBoundary><CreatePostFAB /></SafeBoundary>}
         </div>
     );

--- a/features/wallet/BalanceSidebar/BalanceSidebar.tsx
+++ b/features/wallet/BalanceSidebar/BalanceSidebar.tsx
@@ -13,7 +13,9 @@ import {
 } from "@gravity-ui/icons";
 
 import { useBalance, useTransactions } from "@/lib/hooks/use-wallet";
+import { useIsSeller } from "@/lib/hooks/use-is-seller";
 import { useUIStore } from "@/lib/stores/ui-store";
+import { BUYER_WALLET_ENABLED } from "@/lib/flags";
 import { pickAvailableCLP, labelForKind } from "@/features/wallet/shared";
 import {
     formatCurrency,
@@ -65,6 +67,11 @@ export default function BalanceSidebar() {
 
     const { data: balanceData, isLoading: balanceLoading } = useBalance();
     const { data: txData, isLoading: txLoading } = useTransactions({ limit: 4 });
+    const { isSeller } = useIsSeller();
+    const showDeposit = BUYER_WALLET_ENABLED;
+    const showPayout = isSeller;
+    const showActions = showDeposit || showPayout;
+    const showHint = !showDeposit && !showPayout;
 
     const clp = useMemo(() => pickAvailableCLP(balanceData?.accounts), [balanceData]);
     const currency = clp?.currency ?? "CLP";
@@ -201,32 +208,65 @@ export default function BalanceSidebar() {
                         </div>
                     </div>
 
-                    {/* Quick actions */}
-                    <div className="grid grid-cols-2 gap-2 mt-3">
-                        <button
-                            type="button"
-                            onClick={openDeposit}
-                            className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold bg-accent text-white cursor-pointer transition-opacity hover:opacity-90"
-                            aria-label="Recargar saldo"
+                    {/* Quick actions — se muestran según flag (buyer wallet) y perfil de seller */}
+                    {showActions && (
+                        <div
+                            className={`grid gap-2 mt-3 ${
+                                showDeposit && showPayout ? "grid-cols-2" : "grid-cols-1"
+                            }`}
                         >
-                            <Plus className="size-3.5" />
-                            Recargar
-                        </button>
-                        <button
-                            type="button"
-                            onClick={openPayout}
-                            className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold cursor-pointer transition-colors hover:bg-foreground/5"
+                            {showDeposit && (
+                                <button
+                                    type="button"
+                                    onClick={openDeposit}
+                                    className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold bg-accent text-white cursor-pointer transition-opacity hover:opacity-90"
+                                    aria-label="Recargar saldo"
+                                >
+                                    <Plus className="size-3.5" />
+                                    Recargar
+                                </button>
+                            )}
+                            {showPayout && (
+                                <button
+                                    type="button"
+                                    onClick={openPayout}
+                                    className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold cursor-pointer transition-colors hover:bg-foreground/5"
+                                    style={{
+                                        backgroundColor: "var(--surface-solid)",
+                                        border: "1px solid var(--border)",
+                                        color: "var(--foreground)",
+                                    }}
+                                    aria-label="Retirar saldo"
+                                >
+                                    <ArrowUpFromSquare className="size-3.5" />
+                                    Retirar
+                                </button>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Hint para usuarios que no son sellers y no tienen buyer wallet */}
+                    {showHint && (
+                        <div
+                            className="mt-3 rounded-xl px-3 py-2.5 text-[11px] leading-relaxed"
                             style={{
                                 backgroundColor: "var(--surface-solid)",
                                 border: "1px solid var(--border)",
-                                color: "var(--foreground)",
+                                color: "var(--muted)",
                             }}
-                            aria-label="Retirar saldo"
                         >
-                            <ArrowUpFromSquare className="size-3.5" />
-                            Retirar
-                        </button>
-                    </div>
+                            Tus compras se cobran directo al pagar. Si vendés cartas,{" "}
+                            <Link
+                                href="/marketplace/seller-setup"
+                                onClick={onClose}
+                                className="font-semibold underline"
+                                style={{ color: "var(--accent)" }}
+                            >
+                                activá tu perfil de vendedor
+                            </Link>{" "}
+                            para retirar tus ganancias.
+                        </div>
+                    )}
                 </div>
 
                 {/* Recent movements */}

--- a/features/wallet/BalanceSidebar/BalanceSidebar.tsx
+++ b/features/wallet/BalanceSidebar/BalanceSidebar.tsx
@@ -59,6 +59,8 @@ function TransactionRow({ tx }: { tx: WalletTransaction }) {
 export default function BalanceSidebar() {
     const isOpen = useUIStore((s) => s.balanceSidebarOpen);
     const onClose = useUIStore((s) => s.closeBalanceSidebar);
+    const openDeposit = useUIStore((s) => s.openDepositModal);
+    const openPayout = useUIStore((s) => s.openPayoutModal);
     const panelRef = useRef<HTMLDivElement>(null);
 
     const { data: balanceData, isLoading: balanceLoading } = useBalance();
@@ -199,24 +201,27 @@ export default function BalanceSidebar() {
                         </div>
                     </div>
 
-                    {/* Quick actions — disabled until deposit/withdraw endpoints land */}
+                    {/* Quick actions */}
                     <div className="grid grid-cols-2 gap-2 mt-3">
                         <button
                             type="button"
-                            disabled
-                            className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold bg-surface-solid text-muted opacity-60 cursor-not-allowed"
-                            aria-label="Recargar saldo (próximamente)"
-                            title="Próximamente"
+                            onClick={openDeposit}
+                            className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold bg-accent text-white cursor-pointer transition-opacity hover:opacity-90"
+                            aria-label="Recargar saldo"
                         >
                             <Plus className="size-3.5" />
                             Recargar
                         </button>
                         <button
                             type="button"
-                            disabled
-                            className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold bg-surface-solid text-muted opacity-60 cursor-not-allowed"
-                            aria-label="Retirar saldo (próximamente)"
-                            title="Próximamente"
+                            onClick={openPayout}
+                            className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold cursor-pointer transition-colors hover:bg-foreground/5"
+                            style={{
+                                backgroundColor: "var(--surface-solid)",
+                                border: "1px solid var(--border)",
+                                color: "var(--foreground)",
+                            }}
+                            aria-label="Retirar saldo"
                         >
                             <ArrowUpFromSquare className="size-3.5" />
                             Retirar

--- a/features/wallet/DepositModal/DepositModal.tsx
+++ b/features/wallet/DepositModal/DepositModal.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@heroui/react/button";
+import { Card } from "@heroui/react/card";
+import { Input } from "@heroui/react/input";
+import {
+    Xmark,
+    CreditCard,
+    CircleInfo,
+    TriangleExclamation,
+} from "@gravity-ui/icons";
+
+import { useUIStore } from "@/lib/stores/ui-store";
+import { useCreateDeposit } from "@/lib/hooks/use-wallet";
+import { labelForProvider } from "@/features/wallet/shared";
+import { ApiError } from "@/lib/api/errors";
+import type { PaymentProviderCode } from "@/lib/types/wallet";
+
+const PROVIDERS: Array<{ value: PaymentProviderCode; label: string }> = [
+    { value: "flow", label: "Flow" },
+    { value: "webpay", label: "Webpay" },
+    { value: "mercadopago", label: "Mercado Pago" },
+];
+
+const MIN_AMOUNT = 1000;
+const MAX_AMOUNT = 500_000;
+
+function generateIdempotenceKey(): string {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+    }
+    return `dep-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Wrapper mounts/unmounts the inner dialog, giving us a clean
+ * state reset (and a fresh idempotence key) on every open.
+ */
+export default function DepositModal() {
+    const isOpen = useUIStore((s) => s.depositModalOpen);
+    if (!isOpen) return null;
+    return <DepositDialog />;
+}
+
+function DepositDialog() {
+    const onClose = useUIStore((s) => s.closeDepositModal);
+    const createDeposit = useCreateDeposit();
+
+    // Lazy initialisers run once on mount — no cascading setState in an effect.
+    const [amount, setAmount] = useState<string>("10000");
+    const [provider, setProvider] = useState<PaymentProviderCode>("flow");
+    const [idempotenceKey] = useState<string>(() => generateIdempotenceKey());
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [providerOffline, setProviderOffline] = useState<PaymentProviderCode | null>(null);
+
+    // Escape closes the modal when not submitting.
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === "Escape" && !createDeposit.isPending) onClose();
+        };
+        document.addEventListener("keydown", handler);
+        return () => document.removeEventListener("keydown", handler);
+    }, [onClose, createDeposit.isPending]);
+
+    // Lock body scroll while open.
+    useEffect(() => {
+        const prev = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        return () => {
+            document.body.style.overflow = prev;
+        };
+    }, []);
+
+    const amountNum = useMemo(() => {
+        const n = parseInt(amount, 10);
+        return Number.isFinite(n) ? n : 0;
+    }, [amount]);
+
+    const amountError = useMemo(() => {
+        if (!amount) return null;
+        if (amountNum < MIN_AMOUNT) return `Monto mínimo: $${MIN_AMOUNT.toLocaleString("es-CL")}`;
+        if (amountNum > MAX_AMOUNT) return `Monto máximo: $${MAX_AMOUNT.toLocaleString("es-CL")}`;
+        return null;
+    }, [amount, amountNum]);
+
+    const canSubmit =
+        !createDeposit.isPending &&
+        amountNum >= MIN_AMOUNT &&
+        amountNum <= MAX_AMOUNT &&
+        !!provider &&
+        !!idempotenceKey;
+
+    async function handleSubmit() {
+        if (!canSubmit) return;
+        setErrorMessage(null);
+        setProviderOffline(null);
+
+        try {
+            const res = await createDeposit.mutateAsync({
+                provider_code: provider,
+                amount: String(amountNum),
+                currency: "CLP",
+                idempotence_key: idempotenceKey,
+            });
+            if (res.redirect_url) {
+                window.location.href = res.redirect_url;
+                return;
+            }
+            // No redirect URL — unusual but treat as success fallback.
+            onClose();
+        } catch (err: unknown) {
+            if (err instanceof ApiError) {
+                // Provider not configured / not implemented → show friendly banner.
+                if (err.status === 501 || err.code === "NOT_IMPLEMENTED") {
+                    setProviderOffline(provider);
+                    return;
+                }
+                if (
+                    err.status === 400 &&
+                    (err.code === "BAD_REQUEST" || /no active config/i.test(err.message))
+                ) {
+                    setProviderOffline(provider);
+                    return;
+                }
+                if (err.status === 409) {
+                    setErrorMessage("Ya existe una recarga pendiente con esta referencia.");
+                    return;
+                }
+                setErrorMessage(err.message || "No pudimos iniciar la recarga. Intenta más tarde.");
+                return;
+            }
+            setErrorMessage(
+                err instanceof Error
+                    ? err.message
+                    : "No pudimos iniciar la recarga. Intenta más tarde.",
+            );
+        }
+    }
+
+    return (
+        <div
+            className="fixed inset-0 z-[80] flex items-center justify-center"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Recargar saldo"
+        >
+            <button
+                type="button"
+                aria-label="Cerrar recargar saldo"
+                className="absolute inset-0 bg-black/50"
+                onClick={() => {
+                    if (!createDeposit.isPending) onClose();
+                }}
+            />
+            <Card
+                className="surface-card relative z-10 w-full max-w-md mx-4 rounded-2xl"
+                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            >
+                <Card.Content className="p-6 space-y-4">
+                    {/* Header */}
+                    <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-2.5">
+                            <div className="w-8 h-8 rounded-full flex items-center justify-center bg-accent/15 text-accent">
+                                <CreditCard className="size-4" />
+                            </div>
+                            <h2 className="text-lg font-bold m-0 text-[var(--foreground)]">
+                                Recargar saldo
+                            </h2>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                if (!createDeposit.isPending) onClose();
+                            }}
+                            className="w-8 h-8 flex items-center justify-center rounded-full cursor-pointer transition-colors hover:bg-foreground/5"
+                            style={{ color: "var(--muted)" }}
+                            aria-label="Cerrar"
+                            disabled={createDeposit.isPending}
+                        >
+                            <Xmark style={{ width: 16, height: 16 }} />
+                        </button>
+                    </div>
+
+                    {/* Amount */}
+                    <div className="space-y-1">
+                        <label
+                            htmlFor="deposit-amount"
+                            className="text-xs font-semibold text-[var(--muted)] uppercase tracking-wider"
+                        >
+                            Monto a recargar (CLP)
+                        </label>
+                        <Input
+                            id="deposit-amount"
+                            aria-label="Monto a recargar en pesos chilenos"
+                            type="number"
+                            inputMode="numeric"
+                            min={MIN_AMOUNT}
+                            max={MAX_AMOUNT}
+                            step={1000}
+                            value={amount}
+                            onChange={(e) => setAmount(e.target.value)}
+                            placeholder={`Ej: 10000 (mínimo ${MIN_AMOUNT.toLocaleString("es-CL")})`}
+                        />
+                        <p className="text-[11px] m-0" style={{ color: "var(--muted)" }}>
+                            Rango permitido: ${MIN_AMOUNT.toLocaleString("es-CL")} — ${MAX_AMOUNT.toLocaleString("es-CL")} CLP
+                        </p>
+                        {amountError && (
+                            <p className="text-[11px] m-0" style={{ color: "#b53000" }}>
+                                {amountError}
+                            </p>
+                        )}
+                    </div>
+
+                    {/* Provider */}
+                    <div className="space-y-1">
+                        <label
+                            htmlFor="deposit-provider"
+                            className="text-xs font-semibold text-[var(--muted)] uppercase tracking-wider"
+                        >
+                            Pasarela de pago
+                        </label>
+                        <select
+                            id="deposit-provider"
+                            aria-label="Selecciona una pasarela de pago"
+                            value={provider}
+                            onChange={(e) => {
+                                setProvider(e.target.value as PaymentProviderCode);
+                                setProviderOffline(null);
+                                setErrorMessage(null);
+                            }}
+                            className="w-full h-10 rounded-xl px-3 text-sm font-medium"
+                            style={{
+                                backgroundColor: "var(--surface-solid)",
+                                border: "1px solid var(--border)",
+                                color: "var(--foreground)",
+                            }}
+                        >
+                            {PROVIDERS.map((p) => (
+                                <option key={p.value} value={p.value}>
+                                    {p.label}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    {/* Provider offline banner */}
+                    {providerOffline && (
+                        <div
+                            role="alert"
+                            className="flex items-start gap-2 rounded-xl p-3"
+                            style={{
+                                backgroundColor: "rgba(245,158,11,0.12)",
+                                border: "1px solid rgba(245,158,11,0.35)",
+                                color: "#92400e",
+                            }}
+                        >
+                            <TriangleExclamation className="size-4 mt-0.5 shrink-0" />
+                            <p className="text-[12px] leading-relaxed m-0">
+                                La pasarela <strong>{labelForProvider(providerOffline)}</strong> aún no está habilitada.
+                                Estamos trabajando en su activación.
+                            </p>
+                        </div>
+                    )}
+
+                    {/* Generic error */}
+                    {errorMessage && !providerOffline && (
+                        <div
+                            role="alert"
+                            className="flex items-start gap-2 rounded-xl p-3"
+                            style={{
+                                backgroundColor: "rgba(246,61,0,0.1)",
+                                border: "1px solid rgba(246,61,0,0.3)",
+                                color: "#b53000",
+                            }}
+                        >
+                            <TriangleExclamation className="size-4 mt-0.5 shrink-0" />
+                            <p className="text-[12px] leading-relaxed m-0">{errorMessage}</p>
+                        </div>
+                    )}
+
+                    {/* Beta disclaimer */}
+                    <div
+                        role="note"
+                        className="flex items-start gap-2 rounded-xl p-3 text-[11px] leading-relaxed"
+                        style={{
+                            backgroundColor: "var(--surface-solid)",
+                            border: "1px solid var(--border)",
+                            color: "var(--muted)",
+                        }}
+                    >
+                        <CircleInfo className="size-4 mt-0.5 shrink-0" aria-hidden="true" />
+                        <span>
+                            El módulo de pagos está en beta. Si necesitas recargar saldo urgente,
+                            escríbenos a <strong>soporte@rankeao.cl</strong>.
+                        </span>
+                    </div>
+
+                    {/* Actions */}
+                    <div className="flex gap-3 pt-1">
+                        <Button
+                            variant="tertiary"
+                            className="flex-1"
+                            onPress={onClose}
+                            isDisabled={createDeposit.isPending}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button
+                            variant="primary"
+                            className="flex-1 font-semibold"
+                            onPress={handleSubmit}
+                            isPending={createDeposit.isPending}
+                            isDisabled={!canSubmit}
+                        >
+                            {createDeposit.isPending ? "Redirigiendo..." : "Ir a pagar"}
+                        </Button>
+                    </div>
+                </Card.Content>
+            </Card>
+        </div>
+    );
+}

--- a/features/wallet/DepositModal/index.ts
+++ b/features/wallet/DepositModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DepositModal";

--- a/features/wallet/PayoutRequestModal/PayoutRequestModal.tsx
+++ b/features/wallet/PayoutRequestModal/PayoutRequestModal.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@heroui/react/button";
+import { Card } from "@heroui/react/card";
+import { Input } from "@heroui/react/input";
+import { TextArea } from "@heroui/react/textarea";
+import {
+    Xmark,
+    ArrowUpFromSquare,
+    CircleInfo,
+    TriangleExclamation,
+    Check,
+} from "@gravity-ui/icons";
+
+import { useUIStore } from "@/lib/stores/ui-store";
+import { useBalance, useCreatePayout } from "@/lib/hooks/use-wallet";
+import { pickAvailableCLP } from "@/features/wallet/shared";
+import { formatCurrency } from "@/lib/utils/format";
+import { ApiError } from "@/lib/api/errors";
+
+const MIN_AMOUNT = 10_000;
+const BANK_DETAILS_PLACEHOLDER = `Banco: (ej. Banco de Chile, BancoEstado, Santander, etc.)
+Tipo de Cuenta: (Cuenta Corriente / Cuenta Vista / CuentaRUT)
+RUT: 12.345.678-9
+Nombre completo del titular:
+Número de cuenta:`;
+
+function generateIdempotenceKey(): string {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+    }
+    return `pay-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Wrapper mounts/unmounts the inner dialog, giving us a clean
+ * state reset (and a fresh idempotence key) on every open.
+ */
+export default function PayoutRequestModal() {
+    const isOpen = useUIStore((s) => s.payoutModalOpen);
+    if (!isOpen) return null;
+    return <PayoutDialog />;
+}
+
+function PayoutDialog() {
+    const onClose = useUIStore((s) => s.closePayoutModal);
+    const createPayout = useCreatePayout();
+
+    const { data: balanceData } = useBalance();
+    const clp = useMemo(() => pickAvailableCLP(balanceData?.accounts), [balanceData]);
+    const availableStr = clp?.available ?? "0";
+    const availableNum = useMemo(() => {
+        const n = parseFloat(availableStr);
+        return Number.isFinite(n) ? n : 0;
+    }, [availableStr]);
+
+    const [amount, setAmount] = useState<string>("");
+    const [bankDetails, setBankDetails] = useState<string>("");
+    const [idempotenceKey] = useState<string>(() => generateIdempotenceKey());
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [success, setSuccess] = useState<boolean>(false);
+
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === "Escape" && !createPayout.isPending) onClose();
+        };
+        document.addEventListener("keydown", handler);
+        return () => document.removeEventListener("keydown", handler);
+    }, [onClose, createPayout.isPending]);
+
+    useEffect(() => {
+        const prev = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        return () => {
+            document.body.style.overflow = prev;
+        };
+    }, []);
+
+    const amountNum = useMemo(() => {
+        const n = parseInt(amount, 10);
+        return Number.isFinite(n) ? n : 0;
+    }, [amount]);
+
+    const amountError = useMemo(() => {
+        if (!amount) return null;
+        if (amountNum < MIN_AMOUNT) {
+            return `Monto mínimo: $${MIN_AMOUNT.toLocaleString("es-CL")}`;
+        }
+        if (amountNum > availableNum) {
+            return `Saldo insuficiente. Disponible: ${formatCurrency(availableStr, "CLP")}`;
+        }
+        return null;
+    }, [amount, amountNum, availableNum, availableStr]);
+
+    const trimmedDetails = bankDetails.trim();
+    const bankDetailsError = useMemo(() => {
+        if (!bankDetails) return null;
+        if (trimmedDetails.length < 10) {
+            return "Describe tus datos bancarios (mínimo 10 caracteres).";
+        }
+        return null;
+    }, [bankDetails, trimmedDetails]);
+
+    const canSubmit =
+        !createPayout.isPending &&
+        !success &&
+        amountNum >= MIN_AMOUNT &&
+        amountNum <= availableNum &&
+        trimmedDetails.length >= 10 &&
+        !!idempotenceKey;
+
+    async function handleSubmit() {
+        if (!canSubmit) return;
+        setErrorMessage(null);
+
+        try {
+            await createPayout.mutateAsync({
+                amount: String(amountNum),
+                currency: "CLP",
+                bank_details: trimmedDetails,
+                idempotence_key: idempotenceKey,
+            });
+            setSuccess(true);
+            // Give the user a brief moment to see confirmation before closing.
+            setTimeout(() => {
+                onClose();
+            }, 1800);
+        } catch (err: unknown) {
+            if (err instanceof ApiError) {
+                setErrorMessage(err.message || "No pudimos crear la solicitud.");
+                return;
+            }
+            setErrorMessage(
+                err instanceof Error ? err.message : "No pudimos crear la solicitud.",
+            );
+        }
+    }
+
+    return (
+        <div
+            className="fixed inset-0 z-[80] flex items-center justify-center"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Retirar saldo"
+        >
+            <button
+                type="button"
+                aria-label="Cerrar retirar saldo"
+                className="absolute inset-0 bg-black/50"
+                onClick={() => {
+                    if (!createPayout.isPending) onClose();
+                }}
+            />
+            <Card
+                className="surface-card relative z-10 w-full max-w-lg mx-4 rounded-2xl"
+                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            >
+                <Card.Content className="p-6 space-y-4">
+                    {/* Header */}
+                    <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-2.5">
+                            <div className="w-8 h-8 rounded-full flex items-center justify-center bg-accent/15 text-accent">
+                                <ArrowUpFromSquare className="size-4" />
+                            </div>
+                            <h2 className="text-lg font-bold m-0 text-[var(--foreground)]">
+                                Retirar saldo
+                            </h2>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                if (!createPayout.isPending) onClose();
+                            }}
+                            className="w-8 h-8 flex items-center justify-center rounded-full cursor-pointer transition-colors hover:bg-foreground/5"
+                            style={{ color: "var(--muted)" }}
+                            aria-label="Cerrar"
+                            disabled={createPayout.isPending}
+                        >
+                            <Xmark style={{ width: 16, height: 16 }} />
+                        </button>
+                    </div>
+
+                    {/* Available balance */}
+                    <div
+                        className="flex items-center justify-between rounded-xl px-3 py-2"
+                        style={{
+                            backgroundColor: "var(--surface-solid)",
+                            border: "1px solid var(--border)",
+                        }}
+                    >
+                        <span
+                            className="text-[11px] font-semibold uppercase tracking-wider"
+                            style={{ color: "var(--muted)" }}
+                        >
+                            Saldo disponible
+                        </span>
+                        <span
+                            className="text-sm font-extrabold tabular-nums"
+                            style={{ color: "var(--foreground)" }}
+                        >
+                            {formatCurrency(availableStr, "CLP")}
+                        </span>
+                    </div>
+
+                    {/* Success banner */}
+                    {success && (
+                        <div
+                            role="status"
+                            aria-live="polite"
+                            className="flex items-start gap-2 rounded-xl p-3"
+                            style={{
+                                backgroundColor: "rgba(0,178,75,0.12)",
+                                border: "1px solid rgba(0,178,75,0.35)",
+                                color: "#00733c",
+                            }}
+                        >
+                            <Check className="size-4 mt-0.5 shrink-0" />
+                            <p className="text-[12px] leading-relaxed m-0">
+                                Solicitud de retiro enviada. Te contactaremos pronto para confirmar los datos.
+                            </p>
+                        </div>
+                    )}
+
+                    {!success && (
+                        <>
+                            {/* Amount */}
+                            <div className="space-y-1">
+                                <label
+                                    htmlFor="payout-amount"
+                                    className="text-xs font-semibold text-[var(--muted)] uppercase tracking-wider"
+                                >
+                                    Monto a retirar (CLP)
+                                </label>
+                                <Input
+                                    id="payout-amount"
+                                    aria-label="Monto a retirar en pesos chilenos"
+                                    type="number"
+                                    inputMode="numeric"
+                                    min={MIN_AMOUNT}
+                                    step={1000}
+                                    value={amount}
+                                    onChange={(e) => setAmount(e.target.value)}
+                                    placeholder={`Ej: 40000 (mínimo ${MIN_AMOUNT.toLocaleString("es-CL")})`}
+                                />
+                                {amountError ? (
+                                    <p className="text-[11px] m-0" style={{ color: "#b53000" }}>
+                                        {amountError}
+                                    </p>
+                                ) : (
+                                    <p className="text-[11px] m-0" style={{ color: "var(--muted)" }}>
+                                        Monto mínimo por retiro: ${MIN_AMOUNT.toLocaleString("es-CL")} CLP
+                                    </p>
+                                )}
+                            </div>
+
+                            {/* Bank details */}
+                            <div className="space-y-1">
+                                <label
+                                    htmlFor="payout-bank"
+                                    className="text-xs font-semibold text-[var(--muted)] uppercase tracking-wider"
+                                >
+                                    Datos bancarios
+                                </label>
+                                <TextArea
+                                    id="payout-bank"
+                                    aria-label="Datos bancarios para el retiro"
+                                    placeholder={BANK_DETAILS_PLACEHOLDER}
+                                    value={bankDetails}
+                                    onChange={(e) => setBankDetails(e.target.value)}
+                                    rows={6}
+                                />
+                                {bankDetailsError ? (
+                                    <p className="text-[11px] m-0" style={{ color: "#b53000" }}>
+                                        {bankDetailsError}
+                                    </p>
+                                ) : (
+                                    <p className="text-[11px] m-0" style={{ color: "var(--muted)" }}>
+                                        Completa todos los campos del template. Un admin revisará los datos.
+                                    </p>
+                                )}
+                            </div>
+
+                            {/* Info notes */}
+                            <div
+                                role="note"
+                                className="flex items-start gap-2 rounded-xl p-3 text-[11px] leading-relaxed"
+                                style={{
+                                    backgroundColor: "var(--surface-solid)",
+                                    border: "1px solid var(--border)",
+                                    color: "var(--muted)",
+                                }}
+                            >
+                                <CircleInfo className="size-4 mt-0.5 shrink-0" aria-hidden="true" />
+                                <div className="space-y-1">
+                                    <p className="m-0">
+                                        Tu solicitud pasará por revisión admin antes de procesarse. Te contactaremos
+                                        por email para confirmar los datos.
+                                    </p>
+                                    <p className="m-0">
+                                        El monto será descontado del saldo disponible solo al momento de aprobación.
+                                    </p>
+                                </div>
+                            </div>
+
+                            {/* Generic error */}
+                            {errorMessage && (
+                                <div
+                                    role="alert"
+                                    className="flex items-start gap-2 rounded-xl p-3"
+                                    style={{
+                                        backgroundColor: "rgba(246,61,0,0.1)",
+                                        border: "1px solid rgba(246,61,0,0.3)",
+                                        color: "#b53000",
+                                    }}
+                                >
+                                    <TriangleExclamation className="size-4 mt-0.5 shrink-0" />
+                                    <p className="text-[12px] leading-relaxed m-0">{errorMessage}</p>
+                                </div>
+                            )}
+
+                            {/* Actions */}
+                            <div className="flex gap-3 pt-1">
+                                <Button
+                                    variant="tertiary"
+                                    className="flex-1"
+                                    onPress={onClose}
+                                    isDisabled={createPayout.isPending}
+                                >
+                                    Cancelar
+                                </Button>
+                                <Button
+                                    variant="primary"
+                                    className="flex-1 font-semibold"
+                                    onPress={handleSubmit}
+                                    isPending={createPayout.isPending}
+                                    isDisabled={!canSubmit}
+                                >
+                                    {createPayout.isPending ? "Enviando..." : "Solicitar retiro"}
+                                </Button>
+                            </div>
+                        </>
+                    )}
+                </Card.Content>
+            </Card>
+        </div>
+    );
+}

--- a/features/wallet/PayoutRequestModal/index.ts
+++ b/features/wallet/PayoutRequestModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PayoutRequestModal";

--- a/features/wallet/shared.ts
+++ b/features/wallet/shared.ts
@@ -1,4 +1,9 @@
-import type { WalletAccount, WalletTxKind } from "@/lib/types/wallet";
+import type {
+    WalletAccount,
+    WalletTxKind,
+    PayoutStatus,
+    PaymentProviderCode,
+} from "@/lib/types/wallet";
 
 // ── Spanish labels per transaction kind ──
 
@@ -40,6 +45,77 @@ export interface CurrencyGroup {
     available: string;
     holds: string;
     total: string;
+}
+
+// ── Payout status labels (ES) ──
+
+export const PAYOUT_STATUS_LABELS: Record<PayoutStatus, string> = {
+    REQUESTED: "Solicitado",
+    PENDING_REVIEW: "En revisión",
+    APPROVED: "Aprobado",
+    PROCESSING: "Procesando",
+    COMPLETED: "Completado",
+    FAILED: "Fallido",
+    CANCELLED: "Cancelado",
+    REJECTED: "Rechazado",
+};
+
+/** HeroUI-like color tokens for status chips. */
+export type StatusTone =
+    | "default"
+    | "warning"
+    | "primary"
+    | "secondary"
+    | "success"
+    | "danger";
+
+export const PAYOUT_STATUS_TONE: Record<PayoutStatus, StatusTone> = {
+    REQUESTED: "default",
+    PENDING_REVIEW: "warning",
+    APPROVED: "primary",
+    PROCESSING: "secondary",
+    COMPLETED: "success",
+    FAILED: "danger",
+    CANCELLED: "default",
+    REJECTED: "danger",
+};
+
+export function labelForPayoutStatus(status: string): string {
+    return (PAYOUT_STATUS_LABELS as Record<string, string>)[status] ?? status;
+}
+
+export function tonalStyleForPayoutStatus(status: string): {
+    bg: string;
+    color: string;
+} {
+    const tone = (PAYOUT_STATUS_TONE as Record<string, StatusTone>)[status] ?? "default";
+    switch (tone) {
+        case "warning":
+            return { bg: "rgba(245,158,11,0.15)", color: "#b45309" };
+        case "primary":
+            return { bg: "rgba(99,102,241,0.15)", color: "#4338ca" };
+        case "secondary":
+            return { bg: "rgba(139,92,246,0.15)", color: "#6d28d9" };
+        case "success":
+            return { bg: "rgba(0,178,75,0.15)", color: "#00733c" };
+        case "danger":
+            return { bg: "rgba(246,61,0,0.15)", color: "#b53000" };
+        case "default":
+        default:
+            return { bg: "var(--surface)", color: "var(--muted)" };
+    }
+}
+
+// ── Payment providers ──
+
+export const PAYMENT_PROVIDER_LABELS: Record<PaymentProviderCode, string> = {
+    flow: "Flow",
+    webpay: "Webpay",
+    mercadopago: "Mercado Pago",
+};
+
+export function labelForProvider(code: string): string {
+    return (PAYMENT_PROVIDER_LABELS as Record<string, string>)[code] ?? code;
 }
 
 export function groupByCurrency(accounts: WalletAccount[] | undefined): CurrencyGroup[] {

--- a/lib/api/wallet.ts
+++ b/lib/api/wallet.ts
@@ -1,10 +1,14 @@
-import { apiFetch } from "./client";
+import { apiFetch, apiPost } from "./client";
 import type { ApiResponse } from "@/lib/types/api";
 import type {
     BalanceResponse,
     TransactionsResponse,
     PayoutsResponse,
     TransactionsParams,
+    CreateDepositRequest,
+    CreateDepositResponse,
+    CreatePayoutRequest,
+    CreatePayoutResponse,
 } from "@/lib/types/wallet";
 
 // ── Balance ──
@@ -51,4 +55,35 @@ export async function getPayouts(token?: string): Promise<PayoutsResponse> {
     });
     const data = res?.data ?? res;
     return { payouts: Array.isArray(data?.payouts) ? data.payouts : [] };
+}
+
+// ── Mutations ──
+
+export async function createDeposit(
+    body: CreateDepositRequest,
+    token?: string,
+): Promise<CreateDepositResponse> {
+    const res = await apiPost<ApiResponse<CreateDepositResponse>>(
+        "/payments/deposits",
+        body,
+        { token },
+    );
+    const data = res?.data ?? (res as unknown as CreateDepositResponse);
+    return {
+        deposit_id: data?.deposit_id ?? "",
+        redirect_url: data?.redirect_url,
+    };
+}
+
+export async function createPayout(
+    body: CreatePayoutRequest,
+    token?: string,
+): Promise<CreatePayoutResponse> {
+    const res = await apiPost<ApiResponse<CreatePayoutResponse>>(
+        "/wallet/payouts",
+        body,
+        { token },
+    );
+    const data = res?.data ?? (res as unknown as CreatePayoutResponse);
+    return { payout: data?.payout as CreatePayoutResponse["payout"] };
 }

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,21 @@
+/**
+ * Feature flags de la app.
+ *
+ * Los flags controlan features en desarrollo o pivots de producto. Se leen
+ * desde variables de entorno expuestas al browser (prefijo `NEXT_PUBLIC_*`)
+ * y quedan inlined en el bundle en build time — por eso no deben usarse
+ * para proteger endpoints privados, sólo para ocultar UI.
+ */
+
+/**
+ * Habilita el wallet para BUYERS (recarga de saldo vía DepositModal,
+ * botón "Recargar" en la sidebar, etc).
+ *
+ * El pivot actual apunta a que los compradores paguen directo vía Transbank
+ * al momento de la compra, así que por defecto queda en `false` y el wallet
+ * pasa a ser usado sólo para payouts de sellers.
+ *
+ * Para reactivarlo en Vercel/Railway: setear `NEXT_PUBLIC_BUYER_WALLET_ENABLED=true`.
+ */
+export const BUYER_WALLET_ENABLED =
+    process.env.NEXT_PUBLIC_BUYER_WALLET_ENABLED === "true";

--- a/lib/hooks/use-is-seller.ts
+++ b/lib/hooks/use-is-seller.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getMySellerProfile } from "@/lib/api/marketplace";
+import { useAuthStore } from "@/lib/stores/auth-store";
+import type { SellerProfile } from "@/lib/types/marketplace";
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+
+/**
+ * Resuelve si el usuario autenticado es un seller con perfil activo.
+ *
+ * Estrategia:
+ *   1. Llama a `GET /marketplace/seller/me` (`getMySellerProfile`).
+ *   2. Si devuelve un perfil con `user_id`, es seller ⇒ `true`.
+ *   3. Si devuelve 404 u otro error, asumimos que NO es seller ⇒ `false`.
+ *
+ * El resultado se cachea por 5 minutos para evitar hits repetidos
+ * desde la sidebar, la página de wallet, etc.
+ *
+ * Cuando el usuario no está autenticado el hook queda deshabilitado
+ * y devuelve `isSeller === false`.
+ */
+export function useIsSeller() {
+    const isAuthed = useAuthStore((s) => !!s.accessToken);
+
+    const query = useQuery({
+        queryKey: ["marketplace", "seller", "me", "is-seller"],
+        queryFn: async () => {
+            try {
+                const res = await getMySellerProfile();
+                const profile = (res?.data ?? res?.seller ?? res) as
+                    | (SellerProfile & Record<string, unknown>)
+                    | null
+                    | undefined;
+                return !!profile?.user_id;
+            } catch {
+                // 404 / 401 / etc → no es seller
+                return false;
+            }
+        },
+        enabled: isAuthed,
+        staleTime: FIVE_MINUTES,
+        gcTime: FIVE_MINUTES,
+        retry: false,
+        refetchOnWindowFocus: false,
+    });
+
+    return {
+        isSeller: query.data === true,
+        isLoading: query.isLoading,
+        isFetched: query.isFetched,
+    };
+}

--- a/lib/hooks/use-wallet.ts
+++ b/lib/hooks/use-wallet.ts
@@ -1,9 +1,14 @@
 "use client";
 
-import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as walletApi from "@/lib/api/wallet";
 import { useAuthStore } from "@/lib/stores/auth-store";
-import type { TransactionsParams, TransactionsResponse } from "@/lib/types/wallet";
+import type {
+    TransactionsParams,
+    TransactionsResponse,
+    CreateDepositRequest,
+    CreatePayoutRequest,
+} from "@/lib/types/wallet";
 
 // ── Balance ──
 // Polls every 30s while the page/tab is focused, matching the reference b1tcore UX.
@@ -62,5 +67,24 @@ export function usePayouts() {
         queryKey: ["wallet", "payouts"],
         queryFn: () => walletApi.getPayouts(),
         enabled: isAuthenticated,
+    });
+}
+
+// ── Mutations ──
+
+export function useCreateDeposit() {
+    return useMutation({
+        mutationFn: (body: CreateDepositRequest) => walletApi.createDeposit(body),
+    });
+}
+
+export function useCreatePayout() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (body: CreatePayoutRequest) => walletApi.createPayout(body),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["wallet", "payouts"] });
+            queryClient.invalidateQueries({ queryKey: ["wallet", "balance"] });
+        },
     });
 }

--- a/lib/stores/ui-store.ts
+++ b/lib/stores/ui-store.ts
@@ -23,6 +23,12 @@ interface UIState {
   balanceSidebarOpen: boolean;
   openBalanceSidebar: () => void;
   closeBalanceSidebar: () => void;
+  depositModalOpen: boolean;
+  openDepositModal: () => void;
+  closeDepositModal: () => void;
+  payoutModalOpen: boolean;
+  openPayoutModal: () => void;
+  closePayoutModal: () => void;
 }
 
 export const useUIStore = create<UIState>()((set) => ({
@@ -46,4 +52,10 @@ export const useUIStore = create<UIState>()((set) => ({
   balanceSidebarOpen: false,
   openBalanceSidebar: () => set({ balanceSidebarOpen: true }),
   closeBalanceSidebar: () => set({ balanceSidebarOpen: false }),
+  depositModalOpen: false,
+  openDepositModal: () => set({ depositModalOpen: true, balanceSidebarOpen: false }),
+  closeDepositModal: () => set({ depositModalOpen: false }),
+  payoutModalOpen: false,
+  openPayoutModal: () => set({ payoutModalOpen: true, balanceSidebarOpen: false }),
+  closePayoutModal: () => set({ payoutModalOpen: false }),
 }));

--- a/lib/types/wallet.ts
+++ b/lib/types/wallet.ts
@@ -54,8 +54,62 @@ export interface TransactionsResponse {
     transactions: WalletTransaction[];
 }
 
+// ── Payouts ──
+
+export type PayoutStatus =
+    | "REQUESTED"
+    | "PENDING_REVIEW"
+    | "APPROVED"
+    | "PROCESSING"
+    | "COMPLETED"
+    | "FAILED"
+    | "CANCELLED"
+    | "REJECTED";
+
+export interface WalletPayout {
+    id: string;
+    user_id?: string | number;
+    amount: string;
+    currency: string;
+    status: PayoutStatus;
+    bank_details?: string;
+    rejection_reason?: string | null;
+    created_at: string;
+    resolved_at?: string | null;
+    updated_at?: string;
+}
+
 export interface PayoutsResponse {
-    payouts: unknown[];
+    payouts: WalletPayout[];
+}
+
+// ── Deposits ──
+
+export type PaymentProviderCode = "flow" | "webpay" | "mercadopago";
+
+export interface CreateDepositRequest {
+    provider_code: PaymentProviderCode;
+    amount: string;
+    currency: string;
+    idempotence_key: string;
+}
+
+export interface CreateDepositResponse {
+    deposit_id: string;
+    redirect_url?: string;
+}
+
+// ── Payout request ──
+
+export interface CreatePayoutRequest {
+    amount: string;
+    currency: string;
+    bank_details: string;
+    idempotence_key: string;
+}
+
+export interface CreatePayoutResponse {
+    payout: WalletPayout;
 }
 
 export interface TransactionsParams {


### PR DESCRIPTION
## Resumen

Construye los modales **Recargar** (depositar) y **Retirar** (payout) sobre la
UI read-only de wallet mergeada en #64, más una pestaña de historial de
payouts en \`/wallet\`.

## Qué se entrega

### DepositModal (\`features/wallet/DepositModal\`)
- Input numérico 1.000 – 500.000 CLP con validación en tiempo real.
- \`<select>\` nativo con Flow / Webpay / Mercado Pago.
- \`idempotence_key\` generado con \`crypto.randomUUID()\` en cada apertura
  (el wrapper desmonta al cerrar → reset limpio de estado).
- \`POST /api/v1/payments/deposits\` → redirige a \`redirect_url\` en éxito.
- **Provider offline** (HTTP 501 \`NOT_IMPLEMENTED\`, o 400 \`BAD_REQUEST\` con
  \"no active config\") → banner amarillo con el display-name mapeado.
- **409** → mensaje inline \"Ya existe una recarga pendiente con esta
  referencia\".
- **Banner beta permanente** apuntando a \`soporte@rankeao.cl\`.

### PayoutRequestModal (\`features/wallet/PayoutRequestModal\`)
- Input numérico con mínimo 10.000 CLP.
- \`TextArea\` con placeholder multilinea (Banco / Tipo / RUT / Titular /
  Número), validación de longitud mínima 10.
- Validación frontend: bloquea submit si \`amount > available_balance\` usando
  \`useBalance()\`, con mensaje \"Saldo insuficiente. Disponible: \$X\".
- \`POST /api/v1/wallet/payouts\` → banner verde inline de confirmación y cierre
  automático a los 1.8s, invalidando \`['wallet','payouts']\` y
  \`['wallet','balance']\`.
- Notas informativas sobre revisión admin y descuento al aprobar.

### BalanceSidebar
- Botones \"Recargar\" y \"Retirar\" **activos**, \`aria-label\` actualizado.
- \`openDepositModal\`/\`openPayoutModal\` cierran el sidebar al abrir el modal
  (UX: un solo overlay visible).

### \`/wallet\`
- Nuevas pestañas **Transacciones** (comportamiento original) y **Retiros**.
- Tabla de payouts con: fecha solicitud, monto, badge de estado
  (REQUESTED → REJECTED) con tonos suaves, fecha resuelto y motivo de rechazo.
- Botones header (\"Recargar\" / \"Retirar\") habilitados con \`onPress\` a los
  stores de UI.
- Empty-state ahora CTA al modal de recarga.

### Infra compartida
- \`lib/types/wallet.ts\`: \`WalletPayout\`, \`PayoutStatus\`,
  \`PaymentProviderCode\`, \`CreateDeposit*\`, \`CreatePayout*\`.
- \`lib/api/wallet.ts\`: \`createDeposit\`, \`createPayout\` usando \`apiPost\`.
- \`lib/hooks/use-wallet.ts\`: \`useCreateDeposit\`, \`useCreatePayout\` con
  invalidación TanStack.
- \`features/wallet/shared.ts\`: \`PAYOUT_STATUS_LABELS\`,
  \`tonalStyleForPayoutStatus\`, \`PAYMENT_PROVIDER_LABELS\`.
- \`lib/stores/ui-store.ts\`: \`depositModalOpen\`/\`payoutModalOpen\` con sus
  acciones.
- \`AppShell\` monta ambos modales vía \`next/dynamic\` (ssr:false) dentro de
  \`SafeBoundary\`.

## Decisiones no obvias

1. **Wrapper \"mount-on-open\"** en vez de \`useEffect\` con \`setState\` para
   resetear estado. El lint del repo (\`react-hooks/set-state-in-effect\`)
   bloquea la primera forma. Solución: el componente exportado solo monta un
   inner dialog cuando \`isOpen=true\`, garantizando reset de estado e
   idempotence_key fresco en cada apertura sin cascading renders.
2. **\`<select>\` nativo en vez de \`Select\` de HeroUI v3**: los modales
   existentes del repo (\`OfferModal\`, \`BuyModal\`) usan primitives nativos
   sobre \`Card\` de HeroUI, y la API composicional
   (\`Select.Trigger\`/\`Select.Popover\`/\`ListBox.Item\`) sería
   desproporcionada para 3 opciones. Estilizado con variables CSS del theme.
3. **Tabs custom** en \`/wallet\` (chips redondeados) en lugar de
   \`Tabs\` de HeroUI — replica el patrón de \`FeedTabs\` ya presente en el
   repo, manteniendo consistencia visual.
4. **Error-mapping graceful de proveedor inactivo**: en vez de mostrar el
   mensaje crudo del backend (\"no active config for Flow\"), se detecta por
   \`status\` / \`code\` y se renderiza un banner amarillo con el display name
   localizado (\"La pasarela **Flow** aún no está habilitada…\"). Así, cuando
   una pasarela esté lista, el banner desaparece sin cambio de frontend.
5. **Idempotence key per-open**: se regenera cada vez que el modal monta para
   evitar que un usuario que cierra y vuelve a abrir dispare 409 involuntarios.
6. **\`HeroUI TextArea\`** importado como \`import { TextArea } from
   \"@heroui/react/textarea\"\` — path específico que usa el resto del repo
   (verificado contra \`clanes/new/page.tsx\`).

## Test plan

- [x] \`npx tsc --noEmit\` — sin errores.
- [x] \`npm run build\` — build de producción limpio.
- [x] \`npx eslint\` sobre archivos modificados/creados — sin errores.
- [ ] Manual contra prod \`https://api.rankeao.cl\`:
  - [ ] Click \"Recargar\" → abre modal → select Flow → Ir a pagar → banner
        amarillo \"La pasarela Flow aún no está habilitada\" (esperado por el
        backend 400/501 actual).
  - [ ] Click \"Retirar\" → abre modal → datos bancarios + 10.000 → submit →
        200 → banner verde → tab \"Retiros\" muestra la solicitud con estado
        \"Solicitado\".
  - [ ] Monto mayor a saldo → bloquea submit con mensaje \"Saldo
        insuficiente\".
  - [ ] Escape cierra ambos modales si no hay request en vuelo.