### PR TITLE
feat(wallet): gate buyer wallet, seller-only payouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,10 @@ NEXT_PUBLIC_API_URL=https://api.rankeao.cl/api/v1
 # Invite al server de Discord de Rankeao — usado por el modal de vinculacion
 # en /config. Si no esta seteado, el boton "Abrir Discord" no se muestra.
 NEXT_PUBLIC_DISCORD_INVITE_URL=
+
+# Feature flag: habilita el wallet para BUYERS (recarga de saldo via
+# DepositModal y boton "Recargar" en la sidebar). Con el pivot a Transbank
+# directo queda en "false" por defecto: las compras se cobran al pagar y el
+# wallet pasa a ser usado sólo para payouts de sellers. Ponerlo en "true"
+# para reactivar la recarga en Vercel si se revierte la decisión.
+NEXT_PUBLIC_BUYER_WALLET_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -149,3 +149,11 @@ Archivos clave:
 - `src/app/login/LoginForm.tsx`
 - `src/app/register/RegisterForm.tsx`
 - `src/components/Navbar.tsx`
+
+## 8. Feature Flags
+
+Definidos en `lib/flags.ts`. Se leen desde `NEXT_PUBLIC_*` en build time.
+
+- `NEXT_PUBLIC_BUYER_WALLET_ENABLED` (default: `"false"`)
+  - `true` → muestra el `DepositModal` y el boton "Recargar" en la sidebar/pagina de wallet.
+  - `false` (actual) → el wallet de compradores queda oculto. Las compras se cobran directo via Transbank al pagar en el marketplace. El wallet pasa a ser usado solo para payouts de sellers (detectado via `useIsSeller`, que consulta `GET /marketplace/seller/me`).

--- a/app/(app)/wallet/WalletClient.tsx
+++ b/app/(app)/wallet/WalletClient.tsx
@@ -11,6 +11,8 @@ import {
     useInfiniteTransactions,
     usePayouts,
 } from "@/lib/hooks/use-wallet";
+import { useIsSeller } from "@/lib/hooks/use-is-seller";
+import { BUYER_WALLET_ENABLED } from "@/lib/flags";
 import {
     groupByCurrency,
     labelForKind,
@@ -310,9 +312,26 @@ type WalletTab = "transactions" | "payouts";
 
 function WalletContent() {
     const [kindFilter, setKindFilter] = useState<string>("ALL");
-    const [activeTab, setActiveTab] = useState<WalletTab>("transactions");
+    const [rawActiveTab, setActiveTab] = useState<WalletTab>("transactions");
     const openDeposit = useUIStore((s) => s.openDepositModal);
     const openPayout = useUIStore((s) => s.openPayoutModal);
+    const { isSeller } = useIsSeller();
+
+    const showDepositCTA = BUYER_WALLET_ENABLED;
+    const showPayoutCTA = isSeller;
+    const tabs = useMemo(() => {
+        const base: Array<{ key: WalletTab; label: string }> = [
+            { key: "transactions", label: "Transacciones" },
+        ];
+        if (isSeller) base.push({ key: "payouts", label: "Retiros" });
+        return base;
+    }, [isSeller]);
+
+    // Si el user no es seller pero el estado local quedó en "payouts",
+    // forzamos la tab visible a "transactions" — sin tocar setState en
+    // un effect (para evitar cascading renders).
+    const activeTab: WalletTab =
+        rawActiveTab === "payouts" && !isSeller ? "transactions" : rawActiveTab;
 
     const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
         useInfiniteTransactions(20);
@@ -342,65 +361,70 @@ function WalletContent() {
                 title="Mi wallet"
                 subtitle="Tu saldo disponible y el historial de movimientos en Rankeao."
                 action={
-                    <div className="hidden md:flex flex-col gap-2 min-w-[140px]">
-                        <Button
-                            size="sm"
-                            variant="primary"
-                            className="font-bold"
-                            aria-label="Recargar saldo"
-                            onPress={openDeposit}
-                        >
-                            <Plus className="size-3.5 mr-1.5" />
-                            Recargar
-                        </Button>
-                        <Button
-                            size="sm"
-                            variant="tertiary"
-                            className="font-bold"
-                            aria-label="Retirar saldo"
-                            onPress={openPayout}
-                        >
-                            <ArrowUpFromSquare className="size-3.5 mr-1.5" />
-                            Retirar
-                        </Button>
-                    </div>
+                    showDepositCTA || showPayoutCTA ? (
+                        <div className="hidden md:flex flex-col gap-2 min-w-[140px]">
+                            {showDepositCTA && (
+                                <Button
+                                    size="sm"
+                                    variant="primary"
+                                    className="font-bold"
+                                    aria-label="Recargar saldo"
+                                    onPress={openDeposit}
+                                >
+                                    <Plus className="size-3.5 mr-1.5" />
+                                    Recargar
+                                </Button>
+                            )}
+                            {showPayoutCTA && (
+                                <Button
+                                    size="sm"
+                                    variant="tertiary"
+                                    className="font-bold"
+                                    aria-label="Retirar saldo"
+                                    onPress={openPayout}
+                                >
+                                    <ArrowUpFromSquare className="size-3.5 mr-1.5" />
+                                    Retirar
+                                </Button>
+                            )}
+                        </div>
+                    ) : undefined
                 }
             />
 
             <BalanceCards />
 
-            {/* Tabs */}
-            <div
-                role="tablist"
-                aria-label="Secciones de wallet"
-                className="mx-4 lg:mx-6 mb-3 flex gap-2"
-            >
-                {([
-                    { key: "transactions", label: "Transacciones" },
-                    { key: "payouts", label: "Retiros" },
-                ] as const).map((tab) => {
-                    const isActive = activeTab === tab.key;
-                    return (
-                        <button
-                            key={tab.key}
-                            role="tab"
-                            type="button"
-                            aria-selected={isActive}
-                            onClick={() => setActiveTab(tab.key)}
-                            className="px-4 py-2 rounded-full text-[13px] font-semibold whitespace-nowrap cursor-pointer transition-colors"
-                            style={{
-                                backgroundColor: isActive ? "var(--foreground)" : "var(--surface-solid)",
-                                color: isActive ? "var(--background)" : "var(--muted)",
-                                border: isActive ? "1px solid transparent" : "1px solid var(--border)",
-                            }}
-                        >
-                            {tab.label}
-                        </button>
-                    );
-                })}
-            </div>
+            {/* Tabs — sólo se renderiza la barra si hay más de una tab (ej: seller) */}
+            {tabs.length > 1 && (
+                <div
+                    role="tablist"
+                    aria-label="Secciones de wallet"
+                    className="mx-4 lg:mx-6 mb-3 flex gap-2"
+                >
+                    {tabs.map((tab) => {
+                        const isActive = activeTab === tab.key;
+                        return (
+                            <button
+                                key={tab.key}
+                                role="tab"
+                                type="button"
+                                aria-selected={isActive}
+                                onClick={() => setActiveTab(tab.key)}
+                                className="px-4 py-2 rounded-full text-[13px] font-semibold whitespace-nowrap cursor-pointer transition-colors"
+                                style={{
+                                    backgroundColor: isActive ? "var(--foreground)" : "var(--surface-solid)",
+                                    color: isActive ? "var(--background)" : "var(--muted)",
+                                    border: isActive ? "1px solid transparent" : "1px solid var(--border)",
+                                }}
+                            >
+                                {tab.label}
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
 
-            {activeTab === "payouts" && <PayoutsPanel />}
+            {activeTab === "payouts" && isSeller && <PayoutsPanel />}
             {activeTab === "transactions" && <TransactionsPanel
                 allTxs={allTxs}
                 filtered={filtered}
@@ -413,6 +437,7 @@ function WalletContent() {
                 isFetchingNextPage={isFetchingNextPage}
                 fetchNextPage={fetchNextPage}
                 openDeposit={openDeposit}
+                showDepositCTA={showDepositCTA}
             />}
         </div>
     );
@@ -432,6 +457,7 @@ interface TransactionsPanelProps {
     isFetchingNextPage: boolean;
     fetchNextPage: () => void;
     openDeposit: () => void;
+    showDepositCTA: boolean;
 }
 
 function TransactionsPanel({
@@ -446,6 +472,7 @@ function TransactionsPanel({
     isFetchingNextPage,
     fetchNextPage,
     openDeposit,
+    showDepositCTA,
 }: TransactionsPanelProps) {
     return (
         <>
@@ -538,14 +565,16 @@ function TransactionsPanel({
                             <p className="text-xs mt-1 mb-4" style={{ color: "var(--muted)" }}>
                                 Cuando recibas o gastes saldo aparecerá aquí.
                             </p>
-                            <Button
-                                size="sm"
-                                variant="primary"
-                                aria-label="Recargar saldo"
-                                onPress={openDeposit}
-                            >
-                                Recargar saldo
-                            </Button>
+                            {showDepositCTA && (
+                                <Button
+                                    size="sm"
+                                    variant="primary"
+                                    aria-label="Recargar saldo"
+                                    onPress={openDeposit}
+                                >
+                                    Recargar saldo
+                                </Button>
+                            )}
                         </div>
                     ) : filtered.length === 0 ? (
                         <div className="flex flex-col items-center justify-center py-12 px-6 text-center">

--- a/components/layout/AppShell/AppShell.tsx
+++ b/components/layout/AppShell/AppShell.tsx
@@ -5,11 +5,16 @@ import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
 import Sidebar from "@/components/layout/Sidebar";
 import BottomNav from "@/components/layout/BottomNav";
+import { BUYER_WALLET_ENABLED } from "@/lib/flags";
 
 const CreatePostModal = dynamic(() => import("@/features/social/CreatePostModal"), { ssr: false });
 const CreateDeckModal = dynamic(() => import("@/features/deck/CreateDeckModal"), { ssr: false });
 const CreateListingModal = dynamic(() => import("@/features/marketplace/CreateListingModal"), { ssr: false });
-const DepositModal = dynamic(() => import("@/features/wallet/DepositModal"), { ssr: false });
+// DepositModal sólo se carga cuando el wallet de buyers está habilitado.
+// Con el pivot a Transbank directo queda oculto por defecto — ver lib/flags.ts.
+const DepositModal = BUYER_WALLET_ENABLED
+    ? dynamic(() => import("@/features/wallet/DepositModal"), { ssr: false })
+    : null;
 const PayoutRequestModal = dynamic(() => import("@/features/wallet/PayoutRequestModal"), { ssr: false });
 const CreatePostFAB = dynamic(() => import("@/features/chat/ChatFAB"), { ssr: false });
 
@@ -51,7 +56,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             <SafeBoundary><CreatePostModal /></SafeBoundary>
             <SafeBoundary><CreateDeckModal /></SafeBoundary>
             <SafeBoundary><CreateListingModal /></SafeBoundary>
-            <SafeBoundary><DepositModal /></SafeBoundary>
+            {DepositModal && <SafeBoundary><DepositModal /></SafeBoundary>}
             <SafeBoundary><PayoutRequestModal /></SafeBoundary>
             {!isFixedLayout && <SafeBoundary><CreatePostFAB /></SafeBoundary>}
         </div>

--- a/features/wallet/BalanceSidebar/BalanceSidebar.tsx
+++ b/features/wallet/BalanceSidebar/BalanceSidebar.tsx
@@ -13,7 +13,9 @@ import {
 } from "@gravity-ui/icons";
 
 import { useBalance, useTransactions } from "@/lib/hooks/use-wallet";
+import { useIsSeller } from "@/lib/hooks/use-is-seller";
 import { useUIStore } from "@/lib/stores/ui-store";
+import { BUYER_WALLET_ENABLED } from "@/lib/flags";
 import { pickAvailableCLP, labelForKind } from "@/features/wallet/shared";
 import {
     formatCurrency,
@@ -65,6 +67,11 @@ export default function BalanceSidebar() {
 
     const { data: balanceData, isLoading: balanceLoading } = useBalance();
     const { data: txData, isLoading: txLoading } = useTransactions({ limit: 4 });
+    const { isSeller } = useIsSeller();
+    const showDeposit = BUYER_WALLET_ENABLED;
+    const showPayout = isSeller;
+    const showActions = showDeposit || showPayout;
+    const showHint = !showDeposit && !showPayout;
 
     const clp = useMemo(() => pickAvailableCLP(balanceData?.accounts), [balanceData]);
     const currency = clp?.currency ?? "CLP";
@@ -201,32 +208,65 @@ export default function BalanceSidebar() {
                         </div>
                     </div>
 
-                    {/* Quick actions */}
-                    <div className="grid grid-cols-2 gap-2 mt-3">
-                        <button
-                            type="button"
-                            onClick={openDeposit}
-                            className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold bg-accent text-white cursor-pointer transition-opacity hover:opacity-90"
-                            aria-label="Recargar saldo"
+                    {/* Quick actions — se muestran según flag (buyer wallet) y perfil de seller */}
+                    {showActions && (
+                        <div
+                            className={`grid gap-2 mt-3 ${
+                                showDeposit && showPayout ? "grid-cols-2" : "grid-cols-1"
+                            }`}
                         >
-                            <Plus className="size-3.5" />
-                            Recargar
-                        </button>
-                        <button
-                            type="button"
-                            onClick={openPayout}
-                            className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold cursor-pointer transition-colors hover:bg-foreground/5"
+                            {showDeposit && (
+                                <button
+                                    type="button"
+                                    onClick={openDeposit}
+                                    className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold bg-accent text-white cursor-pointer transition-opacity hover:opacity-90"
+                                    aria-label="Recargar saldo"
+                                >
+                                    <Plus className="size-3.5" />
+                                    Recargar
+                                </button>
+                            )}
+                            {showPayout && (
+                                <button
+                                    type="button"
+                                    onClick={openPayout}
+                                    className="h-10 rounded-xl flex items-center justify-center gap-1.5 text-[12px] font-semibold cursor-pointer transition-colors hover:bg-foreground/5"
+                                    style={{
+                                        backgroundColor: "var(--surface-solid)",
+                                        border: "1px solid var(--border)",
+                                        color: "var(--foreground)",
+                                    }}
+                                    aria-label="Retirar saldo"
+                                >
+                                    <ArrowUpFromSquare className="size-3.5" />
+                                    Retirar
+                                </button>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Hint para usuarios que no son sellers y no tienen buyer wallet */}
+                    {showHint && (
+                        <div
+                            className="mt-3 rounded-xl px-3 py-2.5 text-[11px] leading-relaxed"
                             style={{
                                 backgroundColor: "var(--surface-solid)",
                                 border: "1px solid var(--border)",
-                                color: "var(--foreground)",
+                                color: "var(--muted)",
                             }}
-                            aria-label="Retirar saldo"
                         >
-                            <ArrowUpFromSquare className="size-3.5" />
-                            Retirar
-                        </button>
-                    </div>
+                            Tus compras se cobran directo al pagar. Si vendés cartas,{" "}
+                            <Link
+                                href="/marketplace/seller-setup"
+                                onClick={onClose}
+                                className="font-semibold underline"
+                                style={{ color: "var(--accent)" }}
+                            >
+                                activá tu perfil de vendedor
+                            </Link>{" "}
+                            para retirar tus ganancias.
+                        </div>
+                    )}
                 </div>
 
                 {/* Recent movements */}

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,21 @@
+/**
+ * Feature flags de la app.
+ *
+ * Los flags controlan features en desarrollo o pivots de producto. Se leen
+ * desde variables de entorno expuestas al browser (prefijo `NEXT_PUBLIC_*`)
+ * y quedan inlined en el bundle en build time — por eso no deben usarse
+ * para proteger endpoints privados, sólo para ocultar UI.
+ */
+
+/**
+ * Habilita el wallet para BUYERS (recarga de saldo vía DepositModal,
+ * botón "Recargar" en la sidebar, etc).
+ *
+ * El pivot actual apunta a que los compradores paguen directo vía Transbank
+ * al momento de la compra, así que por defecto queda en `false` y el wallet
+ * pasa a ser usado sólo para payouts de sellers.
+ *
+ * Para reactivarlo en Vercel/Railway: setear `NEXT_PUBLIC_BUYER_WALLET_ENABLED=true`.
+ */
+export const BUYER_WALLET_ENABLED =
+    process.env.NEXT_PUBLIC_BUYER_WALLET_ENABLED === "true";

--- a/lib/hooks/use-is-seller.ts
+++ b/lib/hooks/use-is-seller.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getMySellerProfile } from "@/lib/api/marketplace";
+import { useAuthStore } from "@/lib/stores/auth-store";
+import type { SellerProfile } from "@/lib/types/marketplace";
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+
+/**
+ * Resuelve si el usuario autenticado es un seller con perfil activo.
+ *
+ * Estrategia:
+ *   1. Llama a `GET /marketplace/seller/me` (`getMySellerProfile`).
+ *   2. Si devuelve un perfil con `user_id`, es seller ⇒ `true`.
+ *   3. Si devuelve 404 u otro error, asumimos que NO es seller ⇒ `false`.
+ *
+ * El resultado se cachea por 5 minutos para evitar hits repetidos
+ * desde la sidebar, la página de wallet, etc.
+ *
+ * Cuando el usuario no está autenticado el hook queda deshabilitado
+ * y devuelve `isSeller === false`.
+ */
+export function useIsSeller() {
+    const isAuthed = useAuthStore((s) => !!s.accessToken);
+
+    const query = useQuery({
+        queryKey: ["marketplace", "seller", "me", "is-seller"],
+        queryFn: async () => {
+            try {
+                const res = await getMySellerProfile();
+                const profile = (res?.data ?? res?.seller ?? res) as
+                    | (SellerProfile & Record<string, unknown>)
+                    | null
+                    | undefined;
+                return !!profile?.user_id;
+            } catch {
+                // 404 / 401 / etc → no es seller
+                return false;
+            }
+        },
+        enabled: isAuthed,
+        staleTime: FIVE_MINUTES,
+        gcTime: FIVE_MINUTES,
+        retry: false,
+        refetchOnWindowFocus: false,
+    });
+
+    return {
+        isSeller: query.data === true,
+        isLoading: query.isLoading,
+        isFetched: query.isFetched,
+    };
+}


### PR DESCRIPTION
## Context — product pivot

Original plan was a full internal wallet (buyers top up balance, spend it on the marketplace). We are pivoting:

- **Buyers**: pay directly via Transbank at checkout. No more "recargar saldo".
- **Sellers**: wallet is kept, but only as the destination for marketplace payouts.

PR #65 (DepositModal + PayoutRequestModal + `/wallet` tabs) is NOT reverted. Instead this PR gates the buyer-facing surface behind a feature flag and restricts payout UI to sellers.

Stacked on top of `feature/wallet-deposit-payout-modals` (PR #65). Rebase onto `main` after #65 merges.

## What changes

### 1. Feature flag `NEXT_PUBLIC_BUYER_WALLET_ENABLED`
- New helper `lib/flags.ts` exporting `BUYER_WALLET_ENABLED`.
- Default: `false` (buyer wallet OFF).
- Documented in `.env.example` and `README.md` (§8).

### 2. DepositModal / "Recargar" hidden when flag is off
- `components/layout/AppShell/AppShell.tsx`: `DepositModal` dynamic import is now conditional on `BUYER_WALLET_ENABLED`. When the flag is false the chunk is not shipped at all.
- `features/wallet/BalanceSidebar/BalanceSidebar.tsx`: "Recargar" button only rendered when `BUYER_WALLET_ENABLED === true`.
- `app/(app)/wallet/WalletClient.tsx`: "Recargar" CTA (both in `PageHero` and the empty-state) gated on the same flag.

### 3. "Retirar" / "Retiros" tab restricted to sellers
- New hook `lib/hooks/use-is-seller.ts` (`useIsSeller`): calls `GET /marketplace/seller/me` via TanStack Query, `staleTime: 5min`, `retry: false`, disabled when not authed. Treats any error (including 404) as "not a seller".
- `BalanceSidebar`: "Retirar" button only visible when `isSeller === true`.
- `WalletClient`: the "Retiros" tab is added to the tab list only when `isSeller` is true; if the user previously selected it and loses seller status, we fall back to "Transacciones" during render (no `setState` in effect). Tab bar auto-hides when there's a single tab.
- `PayoutRequestModal` stays mounted globally so the entry-point buttons can trigger it, but it's only reachable from seller-gated buttons.

### 4. UX copy for non-sellers
When the user is not a seller **and** the buyer wallet is disabled, the balance sidebar shows a subtle hint:

> Tus compras se cobran directo al pagar. Si vendés cartas, **activá tu perfil de vendedor** para retirar tus ganancias.

The link points to `/marketplace/seller-setup` (verified route exists).

## How to re-enable the buyer wallet

Set `NEXT_PUBLIC_BUYER_WALLET_ENABLED=true` in Vercel (Project → Settings → Environment Variables) and redeploy. The "Recargar" button, `DepositModal`, and empty-state CTA come back immediately. Seller gating of payouts stays in place regardless.

## QA

- `npx tsc --noEmit` clean.
- `npm run build` clean, no new warnings, all 42 routes generate.
- `npx eslint` clean on all modified files.

## Test plan

- [ ] Non-seller user: visit `/wallet` → only "Transacciones" tab, no tab bar shown, no Retirar button in hero, sidebar hint appears.
- [ ] Seller user: `/wallet` shows both tabs, Retirar button visible in hero and sidebar.
- [ ] Flag OFF (default): Recargar button hidden everywhere, DepositModal chunk not loaded.
- [ ] Flag ON: Recargar button reappears, DepositModal opens.
- [ ] `useIsSeller` caches for 5 min across sidebar + wallet page.