### PR TITLE
feat(promociones): UI chapitas, sorteos y free-form (WS-I)

### DIFF
--- a/app/(app)/mi-cuenta/AccountSidebar.tsx
+++ b/app/(app)/mi-cuenta/AccountSidebar.tsx
@@ -9,6 +9,7 @@ import {
     CreditCard,
     Person,
     ChevronDown,
+    Gift,
 } from "@gravity-ui/icons";
 
 interface AccountNavItem {
@@ -20,6 +21,7 @@ interface AccountNavItem {
 const ACCOUNT_NAV: AccountNavItem[] = [
     { href: "/mi-cuenta/compras", label: "Mis compras", icon: ShoppingCart },
     { href: "/mi-cuenta/ventas", label: "Mis ventas", icon: Tag },
+    { href: "/mi-cuenta/chapitas", label: "Mis chapitas", icon: Gift },
     { href: "/mi-cuenta/billetera", label: "Mi billetera", icon: CreditCard },
     { href: "/mi-cuenta/perfil", label: "Mi perfil", icon: Person },
 ];

--- a/app/(app)/mi-cuenta/chapitas/ChapitasClient.tsx
+++ b/app/(app)/mi-cuenta/chapitas/ChapitasClient.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { Card } from "@heroui/react/card";
+import { Spinner } from "@heroui/react/spinner";
+import { ShoppingCart, TriangleExclamation } from "@gravity-ui/icons";
+
+import ChapitaHash from "@/components/promotions/ChapitaHash";
+import { useMyChapitas } from "@/lib/hooks/use-promotions";
+import { useAuthStore } from "@/lib/stores/auth-store";
+import { mapErrorMessage } from "@/lib/api/errors";
+import type { Chapita } from "@/lib/types/promotions";
+
+function formatDateTime(value: string | undefined): string {
+    if (!value) return "—";
+    try {
+        return new Date(value).toLocaleString("es-CL", {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+    } catch {
+        return value;
+    }
+}
+
+function ChapitaRow({ chapita }: { chapita: Chapita }) {
+    const img = chapita.promotion_art_url;
+    const title = chapita.promotion_title ?? "Promocion";
+    const orderHref = chapita.order_public_id
+        ? `/mi-cuenta/compras/${chapita.order_public_id}`
+        : chapita.order_id
+          ? `/mi-cuenta/compras/${chapita.order_id}`
+          : null;
+
+    return (
+        <Card className="border border-border bg-background">
+            <Card.Content className="p-4">
+                <div className="flex items-center gap-4">
+                    {img ? (
+                        <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-lg bg-surface">
+                            <Image
+                                src={img}
+                                alt={title}
+                                fill
+                                sizes="64px"
+                                className="object-cover"
+                            />
+                        </div>
+                    ) : (
+                        <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg bg-surface text-2xl">
+                            🎟️
+                        </div>
+                    )}
+
+                    <div className="min-w-0 flex-1">
+                        <div className="flex items-center justify-between gap-2">
+                            {chapita.promotion_slug ? (
+                                <Link
+                                    href={`/promociones/${chapita.promotion_slug}`}
+                                    className="truncate text-sm font-bold text-foreground hover:underline"
+                                >
+                                    {title}
+                                </Link>
+                            ) : (
+                                <p className="truncate text-sm font-bold text-foreground">{title}</p>
+                            )}
+                            {chapita.serial_number != null && (
+                                <span className="shrink-0 rounded-full bg-surface px-2 py-0.5 font-mono text-[11px] text-muted">
+                                    #{chapita.serial_number}
+                                </span>
+                            )}
+                        </div>
+
+                        <div className="mt-1 flex flex-wrap items-center gap-3 text-[11px] text-muted">
+                            <span>Minteada el {formatDateTime(chapita.minted_at ?? chapita.created_at)}</span>
+                            {orderHref && (
+                                <Link
+                                    href={orderHref}
+                                    className="text-[var(--accent)] hover:underline"
+                                >
+                                    Ver orden
+                                </Link>
+                            )}
+                        </div>
+
+                        <div className="mt-2">
+                            <ChapitaHash hash={chapita.chapita_hash} />
+                        </div>
+                    </div>
+                </div>
+            </Card.Content>
+        </Card>
+    );
+}
+
+function EmptyState() {
+    return (
+        <div className="rounded-2xl border border-border bg-background p-10 text-center">
+            <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-surface">
+                <ShoppingCart className="size-6 text-muted" />
+            </div>
+            <h2 className="text-base font-bold text-foreground">Aun no tienes chapitas</h2>
+            <p className="mt-2 text-sm text-muted">
+                Compra en el marketplace durante una promocion activa para ganar chapitas
+                digitales y participar automaticamente en los sorteos.
+            </p>
+            <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+                <Link
+                    href="/marketplace"
+                    className="rounded-lg border border-border bg-surface px-4 py-2 text-sm font-semibold text-foreground transition-colors hover:border-[var(--accent)]"
+                >
+                    Ir al marketplace
+                </Link>
+                <Link
+                    href="/promociones"
+                    className="rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+                >
+                    Ver promociones activas
+                </Link>
+            </div>
+        </div>
+    );
+}
+
+export default function ChapitasClient() {
+    const isAuthed = useAuthStore((s) => !!s.accessToken);
+    const hasHydrated = useAuthStore((s) => s._hasHydrated);
+    const query = useMyChapitas();
+
+    if (!hasHydrated) {
+        return (
+            <div className="flex items-center justify-center py-16">
+                <Spinner />
+            </div>
+        );
+    }
+
+    if (!isAuthed) {
+        return (
+            <div className="rounded-2xl border border-border bg-background p-8 text-center">
+                <h2 className="text-base font-bold text-foreground">Inicia sesion</h2>
+                <p className="mt-2 text-sm text-muted">
+                    Para ver tus chapitas necesitas iniciar sesion en Rankeao.
+                </p>
+                <Link
+                    href="/login"
+                    className="mt-4 inline-block rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white"
+                >
+                    Iniciar sesion
+                </Link>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-5">
+            <header className="flex items-center justify-between gap-3">
+                <div>
+                    <h1 className="text-xl font-extrabold text-foreground">Mis chapitas</h1>
+                    <p className="mt-1 text-sm text-muted">
+                        Cada chapita es una entrada verificable a los sorteos Rankeao.
+                    </p>
+                </div>
+            </header>
+
+            {query.isLoading ? (
+                <div className="flex items-center justify-center py-16">
+                    <Spinner />
+                </div>
+            ) : query.isError ? (
+                <div className="flex items-center gap-3 rounded-xl border border-[var(--danger,#ef4444)]/30 bg-[var(--danger,#ef4444)]/10 p-4 text-sm text-foreground">
+                    <TriangleExclamation className="size-5 text-[var(--danger,#ef4444)] shrink-0" />
+                    <span>{mapErrorMessage(query.error)}</span>
+                </div>
+            ) : !query.data || query.data.length === 0 ? (
+                <EmptyState />
+            ) : (
+                <div className="flex flex-col gap-3">
+                    {query.data.map((c) => (
+                        <ChapitaRow key={c.id ?? c.chapita_hash} chapita={c} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/app/(app)/mi-cuenta/chapitas/page.tsx
+++ b/app/(app)/mi-cuenta/chapitas/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import ChapitasClient from "./ChapitasClient";
+
+export const metadata: Metadata = {
+    title: "Mis chapitas",
+    description: "Historial de chapitas digitales y entradas a sorteos Rankeao.",
+    robots: { index: false, follow: false },
+};
+
+export default function ChapitasPage() {
+    return <ChapitasClient />;
+}

--- a/app/(app)/promociones/[slug]/PromotionDetailClient.tsx
+++ b/app/(app)/promociones/[slug]/PromotionDetailClient.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useMemo } from "react";
+import Image from "next/image";
+import { Tabs } from "@heroui/react/tabs";
+import { Spinner } from "@heroui/react/spinner";
+
+import ChapitaHash from "@/components/promotions/ChapitaHash";
+import FreeFormEntryForm from "@/components/promotions/FreeFormEntryForm";
+import WinnersList from "@/components/promotions/WinnersList";
+import { useMyChapitas, useWinners } from "@/lib/hooks/use-promotions";
+import { useAuthStore } from "@/lib/stores/auth-store";
+import type { Promotion } from "@/lib/types/promotions";
+
+function formatDateTime(value: string | undefined): string {
+    if (!value) return "Por confirmar";
+    try {
+        return new Date(value).toLocaleString("es-CL", {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+    } catch {
+        return value;
+    }
+}
+
+function formatCLP(amount: number | undefined): string {
+    if (amount == null) return "—";
+    return amount.toLocaleString("es-CL", {
+        style: "currency",
+        currency: "CLP",
+        minimumFractionDigits: 0,
+    });
+}
+
+interface PromotionDetailClientProps {
+    promotion: Promotion;
+}
+
+export default function PromotionDetailClient({ promotion }: PromotionDetailClientProps) {
+    const isAuthed = useAuthStore((s) => !!s.accessToken);
+    const isDrawn = promotion.status === "DRAWN" || promotion.status === "DELIVERED";
+    const salesOpen = promotion.status === "ACTIVE";
+
+    const winnersQuery = useWinners(isDrawn ? promotion.slug : undefined);
+    const myChapitasQuery = useMyChapitas();
+
+    const myChapitasForPromo = useMemo(() => {
+        const all = myChapitasQuery.data ?? [];
+        return all.filter((c) => c.promotion_slug === promotion.slug);
+    }, [myChapitasQuery.data, promotion.slug]);
+
+    const img = promotion.art_url ?? promotion.image_url;
+    const remaining =
+        promotion.edition_size != null && promotion.minted_count != null
+            ? Math.max(0, promotion.edition_size - promotion.minted_count)
+            : null;
+
+    return (
+        <div className="mx-auto max-w-5xl px-4 lg:px-6 py-6">
+            {/* Hero */}
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-[320px_1fr]">
+                <div className="relative aspect-[4/5] w-full overflow-hidden rounded-2xl border border-border bg-surface">
+                    {img ? (
+                        <Image
+                            src={img}
+                            alt={promotion.title}
+                            fill
+                            sizes="(max-width: 768px) 100vw, 320px"
+                            className="object-cover"
+                            priority
+                        />
+                    ) : (
+                        <div className="flex h-full w-full items-center justify-center text-6xl text-muted">
+                            🎟️
+                        </div>
+                    )}
+                </div>
+
+                <div className="flex flex-col gap-3">
+                    <span className="self-start rounded-full bg-surface px-3 py-1 text-[11px] font-semibold uppercase tracking-wider text-muted">
+                        Chapita + sorteo
+                    </span>
+                    <h1 className="text-2xl font-extrabold text-foreground md:text-3xl">
+                        {promotion.title}
+                    </h1>
+                    {promotion.description && (
+                        <p className="text-sm text-muted whitespace-pre-line">
+                            {promotion.description}
+                        </p>
+                    )}
+
+                    <div className="mt-2 grid grid-cols-2 gap-3">
+                        <div className="rounded-xl border border-border bg-background p-3">
+                            <p className="text-[11px] uppercase tracking-wider text-muted">
+                                Fecha del sorteo
+                            </p>
+                            <p className="mt-1 text-sm font-bold text-foreground">
+                                {formatDateTime(promotion.draw_at)}
+                            </p>
+                        </div>
+                        <div className="rounded-xl border border-border bg-background p-3">
+                            <p className="text-[11px] uppercase tracking-wider text-muted">
+                                Precio chapita
+                            </p>
+                            <p className="mt-1 text-sm font-bold text-foreground">
+                                {formatCLP(promotion.price)}
+                            </p>
+                        </div>
+                        {promotion.prize && (
+                            <div className="col-span-2 rounded-xl border border-border bg-background p-3">
+                                <p className="text-[11px] uppercase tracking-wider text-muted">
+                                    Premio
+                                </p>
+                                <p className="mt-1 text-sm font-bold text-foreground">
+                                    {promotion.prize}
+                                </p>
+                            </div>
+                        )}
+                        {remaining != null && (
+                            <div className="col-span-2 rounded-xl border border-border bg-surface/40 p-3 text-[11px] text-muted">
+                                {remaining > 0 ? (
+                                    <>
+                                        Quedan <strong className="text-foreground">{remaining.toLocaleString("es-CL")}</strong>{" "}
+                                        chapitas disponibles de {promotion.edition_size?.toLocaleString("es-CL")}.
+                                    </>
+                                ) : (
+                                    <>Edicion agotada.</>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            {/* Ganadores (si ya se sorteo) */}
+            {isDrawn && (
+                <section className="mt-8">
+                    <h2 className="mb-3 text-lg font-bold text-foreground">Resultado del sorteo</h2>
+                    {winnersQuery.isLoading ? (
+                        <div className="flex items-center justify-center py-8">
+                            <Spinner />
+                        </div>
+                    ) : (
+                        <WinnersList
+                            winners={winnersQuery.data ?? []}
+                            drawAt={promotion.draw_at}
+                        />
+                    )}
+                </section>
+            )}
+
+            {/* Como participar */}
+            <section className="mt-10">
+                <h2 className="mb-3 text-lg font-bold text-foreground">Como participar</h2>
+
+                <Tabs variant="secondary" className="w-full relative">
+                    <Tabs.ListContainer>
+                        <Tabs.List
+                            aria-label="Metodos de participacion"
+                            className="w-full relative border-b border-[var(--border)] pb-0 rounded-none bg-transparent"
+                        >
+                            <Tabs.Tab id="purchase">
+                                <div className="flex items-center gap-2">
+                                    🛒 <span>Con compra</span>
+                                </div>
+                                <Tabs.Indicator className="bg-[var(--accent)]" />
+                            </Tabs.Tab>
+                            <Tabs.Tab id="free-form">
+                                <div className="flex items-center gap-2">
+                                    ✍️ <span>Sin compra (Ley 19.496)</span>
+                                </div>
+                                <Tabs.Indicator className="bg-[var(--accent)]" />
+                            </Tabs.Tab>
+                        </Tabs.List>
+                    </Tabs.ListContainer>
+
+                    <Tabs.Panel id="purchase">
+                        <div className="mt-4 space-y-4 rounded-2xl border border-border bg-background p-5">
+                            <p className="text-sm text-foreground">
+                                Al comprar cualquier publicacion del{" "}
+                                <strong>marketplace Rankeao</strong> durante esta promocion, se
+                                genera <strong>1 chapita digital</strong> asociada a tu cuenta.
+                                Cada chapita es una entrada automatica al sorteo, con hash
+                                SHA-256 unico y verificable.
+                            </p>
+
+                            {!salesOpen && (
+                                <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-foreground">
+                                    Las ventas de esta promocion estan cerradas. Revisa el resultado del sorteo mas abajo.
+                                </div>
+                            )}
+
+                            {!isAuthed ? (
+                                <p className="text-xs text-muted">
+                                    Inicia sesion para ver tus chapitas asociadas a esta promocion.
+                                </p>
+                            ) : myChapitasQuery.isLoading ? (
+                                <div className="flex items-center gap-2 text-sm text-muted">
+                                    <Spinner size="sm" />
+                                    Cargando tus chapitas...
+                                </div>
+                            ) : myChapitasForPromo.length === 0 ? (
+                                <div className="rounded-lg border border-border bg-surface/40 p-3 text-xs text-muted">
+                                    Aun no tienes chapitas de esta promocion. Cada compra en el
+                                    marketplace durante la vigencia te suma una entrada.
+                                </div>
+                            ) : (
+                                <div>
+                                    <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted">
+                                        Tus chapitas en esta promocion
+                                    </p>
+                                    <ul className="space-y-2">
+                                        {myChapitasForPromo.map((c) => (
+                                            <li
+                                                key={c.id ?? c.chapita_hash}
+                                                className="flex items-center justify-between gap-3 rounded-lg border border-border bg-surface/40 px-3 py-2 text-xs"
+                                            >
+                                                <span className="font-mono text-muted">
+                                                    {c.serial_number != null
+                                                        ? `Serial #${c.serial_number}`
+                                                        : "—"}
+                                                </span>
+                                                <ChapitaHash hash={c.chapita_hash} />
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
+                        </div>
+                    </Tabs.Panel>
+
+                    <Tabs.Panel id="free-form">
+                        <div className="mt-4 rounded-2xl border border-border bg-background p-5">
+                            {salesOpen ? (
+                                <FreeFormEntryForm slug={promotion.slug} />
+                            ) : (
+                                <p className="text-sm text-muted">
+                                    Las inscripciones sin compra estan cerradas para esta promocion.
+                                </p>
+                            )}
+                        </div>
+                    </Tabs.Panel>
+                </Tabs>
+            </section>
+        </div>
+    );
+}

--- a/app/(app)/promociones/[slug]/page.tsx
+++ b/app/(app)/promociones/[slug]/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import PromotionDetailClient from "./PromotionDetailClient";
+import { fetchPromotion } from "@/lib/api/promotions";
+
+interface PromocionDetailPageProps {
+    params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: PromocionDetailPageProps): Promise<Metadata> {
+    const { slug } = await params;
+    try {
+        const promo = await fetchPromotion(slug);
+        if (!promo) {
+            return { title: "Promocion no encontrada" };
+        }
+        return {
+            title: promo.title,
+            description:
+                promo.description ??
+                `Participa en el sorteo de ${promo.title} comprando una chapita o inscribiendote gratis.`,
+        };
+    } catch {
+        return { title: "Promocion" };
+    }
+}
+
+export const revalidate = 60;
+
+export default async function PromocionDetailPage({ params }: PromocionDetailPageProps) {
+    const { slug } = await params;
+
+    let promo: Awaited<ReturnType<typeof fetchPromotion>> = null;
+    try {
+        promo = await fetchPromotion(slug);
+    } catch {
+        promo = null;
+    }
+
+    if (!promo) {
+        notFound();
+    }
+
+    return <PromotionDetailClient promotion={promo} />;
+}

--- a/app/(app)/promociones/page.tsx
+++ b/app/(app)/promociones/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/ui/PageHero";
+import PromotionCard from "@/components/promotions/PromotionCard";
+import { fetchPromotions } from "@/lib/api/promotions";
+
+export const metadata: Metadata = {
+    title: "Promociones",
+    description:
+        "Compra chapitas de edicion limitada y participa automaticamente en sorteos. Tambien puedes inscribirte gratis segun la Ley 19.496.",
+};
+
+export const revalidate = 60;
+
+export default async function PromocionesPage() {
+    let promotions: Awaited<ReturnType<typeof fetchPromotions>> = [];
+    let errored = false;
+    try {
+        promotions = await fetchPromotions();
+    } catch {
+        errored = true;
+    }
+
+    return (
+        <div>
+            <PageHero
+                badge="Sorteos"
+                title="Promociones Rankeao"
+                subtitle="Chapitas de edicion limitada. Cada compra genera una entrada al sorteo. Tambien puedes inscribirte sin compra."
+            />
+
+            <div className="mx-4 lg:mx-6 mt-2">
+                {errored && (
+                    <div className="mb-4 rounded-xl border border-[var(--danger,#ef4444)]/30 bg-[var(--danger,#ef4444)]/10 p-4 text-sm text-foreground">
+                        No pudimos cargar las promociones activas. Intenta nuevamente mas tarde.
+                    </div>
+                )}
+
+                {!errored && promotions.length === 0 && (
+                    <div className="rounded-2xl border border-border bg-background p-10 text-center">
+                        <div className="mx-auto mb-3 text-5xl">🎟️</div>
+                        <h2 className="text-lg font-bold text-foreground">
+                            No hay promociones activas
+                        </h2>
+                        <p className="mt-2 text-sm text-muted">
+                            Vuelve pronto. Publicamos nuevas chapitas y sorteos con regularidad.
+                        </p>
+                    </div>
+                )}
+
+                {promotions.length > 0 && (
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                        {promotions.map((p) => (
+                            <PromotionCard key={p.slug} promotion={p} />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/components/layout/Sidebar/Sidebar.tsx
+++ b/components/layout/Sidebar/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
     Dice1,
     CreditCard,
     Tag,
+    Gift,
 } from "@gravity-ui/icons";
 import { useAuth } from "@/lib/hooks/use-auth";
 import { useUIStore } from "@/lib/stores/ui-store";
@@ -33,6 +34,7 @@ const navItems: NavItem[] = [
     { href: "/", label: "Feed", icon: House },
     { href: "/matches", label: "Partidas", icon: Dice1, authRequired: true },
     { href: "/marketplace", label: "Marketplace", icon: ShoppingCart },
+    { href: "/promociones", label: "Promociones", icon: Gift },
     { href: "/torneos", label: "Torneos", icon: Cup },
     { href: "/comunidades", label: "Comunidades", icon: Persons },
     { href: "/ranking", label: "Ranking", icon: ChartColumn },

--- a/components/promotions/ChapitaHash.tsx
+++ b/components/promotions/ChapitaHash.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "@heroui/react";
+import { Copy, Check } from "@gravity-ui/icons";
+
+interface ChapitaHashProps {
+    hash: string;
+    truncate?: number;
+}
+
+function truncateHash(hash: string, truncate: number): string {
+    if (!hash) return "";
+    if (hash.length <= truncate * 2 + 3) return hash;
+    return `${hash.slice(0, truncate)}...${hash.slice(-truncate)}`;
+}
+
+export default function ChapitaHash({ hash, truncate = 8 }: ChapitaHashProps) {
+    const [copied, setCopied] = useState(false);
+
+    async function handleCopy() {
+        try {
+            await navigator.clipboard.writeText(hash);
+            setCopied(true);
+            toast.success("Hash copiado al portapapeles");
+            setTimeout(() => setCopied(false), 1600);
+        } catch {
+            toast.danger("No pudimos copiar el hash");
+        }
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={handleCopy}
+            title={hash}
+            aria-label="Copiar hash completo"
+            className="group inline-flex items-center gap-2 rounded-md border border-border bg-surface px-2 py-1 font-mono text-[11px] text-foreground transition-colors hover:border-[var(--accent)]"
+        >
+            <span className="truncate">{truncateHash(hash, truncate)}</span>
+            {copied ? (
+                <Check className="size-[13px] text-emerald-500 shrink-0" />
+            ) : (
+                <Copy className="size-[13px] text-muted group-hover:text-foreground shrink-0" />
+            )}
+        </button>
+    );
+}

--- a/components/promotions/FreeFormEntryForm.tsx
+++ b/components/promotions/FreeFormEntryForm.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "@heroui/react";
+import { Button } from "@heroui/react/button";
+
+import { useSubmitFreeForm } from "@/lib/hooks/use-promotions";
+import { formatRut, isValidRut } from "@/lib/utils/rut";
+import { mapErrorMessage } from "@/lib/api/errors";
+import { ApiError } from "@/lib/api/errors";
+
+interface FreeFormEntryFormProps {
+    slug: string;
+    onSuccess?: () => void;
+}
+
+// CAPTCHA real pendiente de integracion (Turnstile/hCaptcha, ver MD 03 §3).
+// Por ahora el usuario escribe el texto mostrado; el backend aceptara el
+// token dummy y el BE real validara cuando se integre el proveedor.
+const MOCK_CAPTCHA_CHALLENGE = "RANKEAO";
+
+type FormErrors = {
+    fullName?: string;
+    rut?: string;
+    email?: string;
+    captcha?: string;
+};
+
+export default function FreeFormEntryForm({ slug, onSuccess }: FreeFormEntryFormProps) {
+    const [fullName, setFullName] = useState("");
+    const [rut, setRut] = useState("");
+    const [email, setEmail] = useState("");
+    const [captcha, setCaptcha] = useState("");
+    const [errors, setErrors] = useState<FormErrors>({});
+    const [submittedOk, setSubmittedOk] = useState(false);
+
+    const mutation = useSubmitFreeForm(slug);
+
+    function validate(): boolean {
+        const next: FormErrors = {};
+        if (fullName.trim().length < 3) {
+            next.fullName = "Ingresa tu nombre completo";
+        }
+        if (!isValidRut(rut)) {
+            next.rut = "RUT invalido (ej: 12.345.678-5)";
+        }
+        if (email && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email.trim())) {
+            next.email = "Email invalido";
+        }
+        if (captcha.trim().toUpperCase() !== MOCK_CAPTCHA_CHALLENGE) {
+            next.captcha = `Escribe exactamente: ${MOCK_CAPTCHA_CHALLENGE}`;
+        }
+        setErrors(next);
+        return Object.keys(next).length === 0;
+    }
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        if (!validate()) return;
+
+        try {
+            await mutation.mutateAsync({
+                full_name: fullName.trim(),
+                rut: formatRut(rut),
+                email: email.trim() || undefined,
+                captcha_token: captcha.trim(),
+            });
+            toast.success("¡Listo! Quedaste participando en el sorteo.");
+            setSubmittedOk(true);
+            setFullName("");
+            setRut("");
+            setEmail("");
+            setCaptcha("");
+            onSuccess?.();
+        } catch (err) {
+            if (err instanceof ApiError && err.status === 429) {
+                toast.danger("Limite alcanzado", {
+                    description: "Ya enviaste una inscripcion hoy o alcanzaste el limite. Intenta nuevamente mas tarde.",
+                });
+                return;
+            }
+            if (err instanceof ApiError && err.status === 409) {
+                toast.danger("RUT ya inscrito", {
+                    description: "Este RUT ya participa en esta promocion sin compra.",
+                });
+                return;
+            }
+            toast.danger("No pudimos registrar tu inscripcion", {
+                description: mapErrorMessage(err),
+            });
+        }
+    }
+
+    if (submittedOk) {
+        return (
+            <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-foreground">
+                <p className="font-semibold">¡Quedaste inscrito en el sorteo!</p>
+                <p className="mt-1 text-muted">
+                    Te contactaremos si resultas ganador. Segun la Ley 19.496 art. 35, la
+                    participacion sin compra tiene las mismas probabilidades que una chapita.
+                </p>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    className="mt-3"
+                    onPress={() => setSubmittedOk(false)}
+                >
+                    Inscribir a otra persona
+                </Button>
+            </div>
+        );
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="rounded-lg border border-border bg-surface/60 p-3 text-xs text-muted">
+                Participa en el sorteo <strong className="text-foreground">sin comprar</strong> nada.
+                Segun la Ley 19.496 art. 35, toda persona con RUT valido puede inscribirse 1 vez
+                por promocion.
+            </div>
+
+            <div className="space-y-1.5">
+                <label htmlFor="ff-name" className="text-xs font-semibold text-muted">
+                    Nombre completo
+                </label>
+                <input
+                    id="ff-name"
+                    type="text"
+                    value={fullName}
+                    onChange={(e) => setFullName(e.target.value)}
+                    autoComplete="name"
+                    required
+                    className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-foreground placeholder:text-muted focus:border-[var(--accent)] focus:outline-none"
+                    placeholder="Ej: Maria Gonzalez"
+                />
+                {errors.fullName && (
+                    <p className="text-xs text-[var(--danger,#ef4444)]">{errors.fullName}</p>
+                )}
+            </div>
+
+            <div className="space-y-1.5">
+                <label htmlFor="ff-rut" className="text-xs font-semibold text-muted">
+                    RUT
+                </label>
+                <input
+                    id="ff-rut"
+                    type="text"
+                    value={rut}
+                    onChange={(e) => setRut(e.target.value)}
+                    onBlur={() => {
+                        if (rut && isValidRut(rut)) setRut(formatRut(rut));
+                    }}
+                    autoComplete="off"
+                    required
+                    className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-foreground placeholder:text-muted focus:border-[var(--accent)] focus:outline-none"
+                    placeholder="12.345.678-5"
+                />
+                {errors.rut && (
+                    <p className="text-xs text-[var(--danger,#ef4444)]">{errors.rut}</p>
+                )}
+            </div>
+
+            <div className="space-y-1.5">
+                <label htmlFor="ff-email" className="text-xs font-semibold text-muted">
+                    Email (opcional)
+                </label>
+                <input
+                    id="ff-email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    autoComplete="email"
+                    className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-foreground placeholder:text-muted focus:border-[var(--accent)] focus:outline-none"
+                    placeholder="maria@ejemplo.cl"
+                />
+                {errors.email && (
+                    <p className="text-xs text-[var(--danger,#ef4444)]">{errors.email}</p>
+                )}
+                <p className="text-[11px] text-muted">
+                    Lo usamos solo para notificarte si resultas ganador.
+                </p>
+            </div>
+
+            <div className="space-y-1.5">
+                <label htmlFor="ff-captcha" className="text-xs font-semibold text-muted">
+                    Verificacion
+                </label>
+                <div className="flex items-center gap-3">
+                    <div
+                        aria-hidden="true"
+                        className="select-none rounded-lg border border-border bg-surface px-3 py-2 font-mono text-sm font-bold tracking-[0.3em] text-foreground"
+                    >
+                        {MOCK_CAPTCHA_CHALLENGE}
+                    </div>
+                    <input
+                        id="ff-captcha"
+                        type="text"
+                        value={captcha}
+                        onChange={(e) => setCaptcha(e.target.value)}
+                        autoComplete="off"
+                        required
+                        className="flex-1 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-foreground placeholder:text-muted focus:border-[var(--accent)] focus:outline-none"
+                        placeholder="Escribe el codigo"
+                    />
+                </div>
+                {errors.captcha && (
+                    <p className="text-xs text-[var(--danger,#ef4444)]">{errors.captcha}</p>
+                )}
+                <p className="text-[11px] text-muted">
+                    CAPTCHA de demostracion. La version final integrara Turnstile/hCaptcha.
+                </p>
+            </div>
+
+            <Button
+                type="submit"
+                variant="primary"
+                isPending={mutation.isPending}
+                className="w-full"
+            >
+                Inscribirme al sorteo
+            </Button>
+        </form>
+    );
+}

--- a/components/promotions/PromotionCard.tsx
+++ b/components/promotions/PromotionCard.tsx
@@ -1,0 +1,124 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { Promotion } from "@/lib/types/promotions";
+
+function formatDate(dateStr: string | undefined): string {
+    if (!dateStr) return "Fecha por confirmar";
+    try {
+        return new Date(dateStr).toLocaleDateString("es-CL", {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+        });
+    } catch {
+        return "Fecha por confirmar";
+    }
+}
+
+function formatCLP(amount: number | undefined): string {
+    if (amount == null) return "—";
+    return amount.toLocaleString("es-CL", {
+        style: "currency",
+        currency: "CLP",
+        minimumFractionDigits: 0,
+    });
+}
+
+function statusLabel(status: Promotion["status"]): { text: string; className: string } {
+    switch (status) {
+        case "ACTIVE":
+            return { text: "Activa", className: "bg-emerald-500/15 text-emerald-500" };
+        case "SALES_CLOSED":
+            return { text: "Ventas cerradas", className: "bg-amber-500/15 text-amber-500" };
+        case "DRAWN":
+            return { text: "Sorteada", className: "bg-blue-500/15 text-blue-500" };
+        case "DELIVERED":
+            return { text: "Entregada", className: "bg-purple-500/15 text-purple-500" };
+        case "CANCELLED":
+            return { text: "Cancelada", className: "bg-red-500/15 text-red-500" };
+        default:
+            return { text: "Proximamente", className: "bg-surface text-muted" };
+    }
+}
+
+interface PromotionCardProps {
+    promotion: Promotion;
+}
+
+export default function PromotionCard({ promotion }: PromotionCardProps) {
+    const img = promotion.art_url ?? promotion.image_url;
+    const status = statusLabel(promotion.status);
+    const remaining =
+        promotion.edition_size != null && promotion.minted_count != null
+            ? Math.max(0, promotion.edition_size - promotion.minted_count)
+            : null;
+
+    return (
+        <Link
+            href={`/promociones/${promotion.slug}`}
+            aria-label={`Ver promocion ${promotion.title}`}
+            className="group flex flex-col overflow-hidden rounded-2xl border border-border bg-background transition-colors hover:border-[var(--accent)]"
+        >
+            <div className="relative aspect-[4/3] w-full overflow-hidden bg-surface">
+                {img ? (
+                    <Image
+                        src={img}
+                        alt={promotion.title}
+                        fill
+                        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                        className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                    />
+                ) : (
+                    <div className="flex h-full w-full items-center justify-center text-4xl text-muted">
+                        🎟️
+                    </div>
+                )}
+                <span
+                    className={`absolute left-3 top-3 rounded-full px-2.5 py-1 text-[11px] font-semibold ${status.className}`}
+                >
+                    {status.text}
+                </span>
+            </div>
+
+            <div className="flex flex-1 flex-col gap-2 p-4">
+                <h3 className="text-base font-bold text-foreground line-clamp-2">
+                    {promotion.title}
+                </h3>
+
+                {promotion.prize && (
+                    <p className="text-xs text-muted line-clamp-2">
+                        <span className="font-semibold text-foreground">Premio: </span>
+                        {promotion.prize}
+                    </p>
+                )}
+
+                <div className="mt-auto flex items-center justify-between pt-2 text-xs">
+                    <div className="flex flex-col">
+                        <span className="text-[10px] uppercase tracking-wider text-muted">
+                            Sorteo
+                        </span>
+                        <span className="font-semibold text-foreground">
+                            {formatDate(promotion.draw_at)}
+                        </span>
+                    </div>
+                    <div className="flex flex-col items-end">
+                        <span className="text-[10px] uppercase tracking-wider text-muted">
+                            Chapita
+                        </span>
+                        <span className="font-semibold text-foreground">
+                            {formatCLP(promotion.price)}
+                        </span>
+                    </div>
+                </div>
+
+                {remaining != null && (
+                    <p className="text-[11px] text-muted">
+                        {remaining > 0
+                            ? `${remaining.toLocaleString("es-CL")} chapitas disponibles`
+                            : "Edicion agotada"}
+                    </p>
+                )}
+            </div>
+        </Link>
+    );
+}

--- a/components/promotions/WinnersList.tsx
+++ b/components/promotions/WinnersList.tsx
@@ -1,0 +1,117 @@
+import type { Winner } from "@/lib/types/promotions";
+import ChapitaHash from "./ChapitaHash";
+
+function formatDateTime(value: string | undefined): string {
+    if (!value) return "—";
+    try {
+        return new Date(value).toLocaleString("es-CL", {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+    } catch {
+        return value;
+    }
+}
+
+function sourceLabel(source: Winner["source"]): string {
+    if (source === "CHAPITA_PURCHASE") return "Chapita";
+    if (source === "FREE_FORM") return "Sin compra";
+    return "—";
+}
+
+interface WinnersListProps {
+    winners: Winner[];
+    drawAt?: string;
+}
+
+export default function WinnersList({ winners, drawAt }: WinnersListProps) {
+    if (!winners.length) {
+        return (
+            <div className="rounded-xl border border-border bg-background p-6 text-center text-sm text-muted">
+                Todavia no hay ganadores publicados.
+            </div>
+        );
+    }
+
+    const sorted = [...winners].sort(
+        (a, b) => (a.winner_index ?? 999) - (b.winner_index ?? 999)
+    );
+
+    return (
+        <div className="overflow-hidden rounded-xl border border-border bg-background">
+            <div className="flex items-center justify-between border-b border-border bg-surface/60 px-4 py-3">
+                <h3 className="text-sm font-bold text-foreground">Ganadores del sorteo</h3>
+                {drawAt && (
+                    <span className="text-[11px] text-muted">
+                        Sorteado el {formatDateTime(drawAt)}
+                    </span>
+                )}
+            </div>
+
+            <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                    <thead className="bg-surface/30 text-left text-[11px] uppercase tracking-wider text-muted">
+                        <tr>
+                            <th scope="col" className="px-4 py-2 font-semibold">#</th>
+                            <th scope="col" className="px-4 py-2 font-semibold">Ganador</th>
+                            <th scope="col" className="px-4 py-2 font-semibold">Origen</th>
+                            <th scope="col" className="px-4 py-2 font-semibold">Serial</th>
+                            <th scope="col" className="px-4 py-2 font-semibold">Hash</th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                        {sorted.map((w, idx) => {
+                            const name =
+                                w.display_name ??
+                                w.username ??
+                                w.full_name ??
+                                "Participante";
+                            return (
+                                <tr key={w.id ?? `${w.winner_index ?? idx}-${w.chapita_hash ?? idx}`}>
+                                    <td className="px-4 py-3 font-mono text-xs text-muted">
+                                        {w.winner_index != null ? `#${w.winner_index + 1}` : `#${idx + 1}`}
+                                    </td>
+                                    <td className="px-4 py-3 font-semibold text-foreground">
+                                        {name}
+                                    </td>
+                                    <td className="px-4 py-3 text-muted">
+                                        {sourceLabel(w.source)}
+                                    </td>
+                                    <td className="px-4 py-3 font-mono text-xs text-foreground">
+                                        {w.serial_number != null ? `#${w.serial_number}` : "—"}
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        {w.chapita_hash ? (
+                                            <ChapitaHash hash={w.chapita_hash} />
+                                        ) : (
+                                            <span className="text-muted">—</span>
+                                        )}
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+
+            {sorted.some((w) => w.seed || w.salt_revealed) && (
+                <div className="border-t border-border bg-surface/30 px-4 py-3 text-[11px] text-muted">
+                    <p>
+                        <strong className="text-foreground">Transparencia del sorteo:</strong>{" "}
+                        El seed y el salt revelado son publicos y permiten verificar que el
+                        sorteo fue determinista.
+                    </p>
+                    {sorted[0]?.seed && (
+                        <p className="mt-1 font-mono">seed: {sorted[0].seed}</p>
+                    )}
+                    {sorted[0]?.salt_revealed && (
+                        <p className="font-mono">salt: {sorted[0].salt_revealed}</p>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/lib/api/promotions.ts
+++ b/lib/api/promotions.ts
@@ -1,0 +1,202 @@
+// API client para promociones (chapitas + sorteos, WS-I).
+// Endpoints bajo /marketplace/promotions/* y /marketplace/me/chapitas.
+
+import { apiFetch, apiPost } from "./client";
+import type {
+    Chapita,
+    FreeFormEntryPayload,
+    FreeFormEntryResponse,
+    MintChapitaPayload,
+    MintChapitaResponse,
+    Promotion,
+    PromotionStatus,
+    Winner,
+} from "@/lib/types/promotions";
+
+// ── Helpers de normalizacion (defensivos: el backend puede evolucionar
+//    devolviendo campos con nombres alternativos, ver patron marketplace-v2). ──
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    if (typeof value !== "object" || value === null) return null;
+    return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asPromotionStatus(value: unknown): PromotionStatus {
+    const s = typeof value === "string" ? value.toUpperCase() : "";
+    const allowed: PromotionStatus[] = [
+        "DRAFT", "ACTIVE", "SALES_CLOSED", "DRAWN", "DELIVERED", "CANCELLED",
+    ];
+    return (allowed as string[]).includes(s) ? (s as PromotionStatus) : "ACTIVE";
+}
+
+function normalizePromotion(raw: unknown): Promotion | null {
+    const r = asRecord(raw);
+    if (!r) return null;
+    const slug = asString(r.slug);
+    const title = asString(r.title) ?? asString(r.name);
+    if (!slug || !title) return null;
+    return {
+        id: asString(r.id),
+        slug,
+        title,
+        description: asString(r.description),
+        prize: asString(r.prize),
+        art_url: asString(r.art_url) ?? asString(r.image_url),
+        image_url: asString(r.image_url) ?? asString(r.art_url),
+        edition_size: asNumber(r.edition_size),
+        minted_count: asNumber(r.minted_count),
+        price: asNumber(r.price),
+        status: asPromotionStatus(r.status),
+        activated_at: asString(r.activated_at),
+        sales_close_at: asString(r.sales_close_at),
+        draw_at: asString(r.draw_at),
+        bases_url: asString(r.bases_url),
+        created_at: asString(r.created_at),
+    };
+}
+
+function normalizeChapita(raw: unknown): Chapita | null {
+    const r = asRecord(raw);
+    if (!r) return null;
+    const hash = asString(r.chapita_hash) ?? asString(r.hash);
+    if (!hash) return null;
+    return {
+        id: asString(r.id),
+        promotion_id: asString(r.promotion_id),
+        promotion_slug: asString(r.promotion_slug),
+        promotion_title: asString(r.promotion_title),
+        promotion_art_url: asString(r.promotion_art_url) ?? asString(r.promotion_image_url),
+        serial_number: asNumber(r.serial_number),
+        chapita_hash: hash,
+        order_id: asString(r.order_id),
+        order_public_id: asString(r.order_public_id),
+        minted_at: asString(r.minted_at),
+        created_at: asString(r.created_at) ?? asString(r.minted_at),
+    };
+}
+
+function normalizeWinner(raw: unknown): Winner | null {
+    const r = asRecord(raw);
+    if (!r) return null;
+    const source = asString(r.source);
+    const typedSource: Winner["source"] =
+        source === "CHAPITA_PURCHASE" || source === "FREE_FORM" ? source : undefined;
+    return {
+        id: asString(r.id),
+        promotion_slug: asString(r.promotion_slug),
+        winner_index: asNumber(r.winner_index),
+        serial_number: asNumber(r.serial_number),
+        chapita_hash: asString(r.chapita_hash),
+        source: typedSource,
+        full_name: asString(r.full_name),
+        username: asString(r.username),
+        display_name: asString(r.display_name),
+        draw_at: asString(r.draw_at),
+        drawn_at: asString(r.drawn_at),
+        seed: asString(r.seed),
+        salt_revealed: asString(r.salt_revealed),
+    };
+}
+
+// Extrae el array de `data`/`promotions`/`chapitas`/`winners` segun el caso.
+function extractArray<T>(res: unknown, keys: string[]): T[] {
+    const r = asRecord(res);
+    if (!r) return [];
+    if (Array.isArray(r.data)) return r.data as T[];
+    for (const k of keys) {
+        if (Array.isArray(r[k])) return r[k] as T[];
+    }
+    const data = asRecord(r.data);
+    if (data) {
+        for (const k of keys) {
+            if (Array.isArray(data[k])) return data[k] as T[];
+        }
+    }
+    return [];
+}
+
+function extractObject(res: unknown): unknown {
+    const r = asRecord(res);
+    if (!r) return null;
+    if (r.data !== undefined) return r.data;
+    return r;
+}
+
+// ── Endpoints ──
+
+export async function fetchPromotions(): Promise<Promotion[]> {
+    const res = await apiFetch<unknown>("/marketplace/promotions", undefined, { revalidate: 60 });
+    const arr = extractArray<unknown>(res, ["promotions"]);
+    return arr.map(normalizePromotion).filter((p): p is Promotion => p !== null);
+}
+
+export async function fetchPromotion(slug: string): Promise<Promotion | null> {
+    const res = await apiFetch<unknown>(`/marketplace/promotions/${encodeURIComponent(slug)}`, undefined, { revalidate: 60 });
+    const raw = extractObject(res);
+    const r = asRecord(raw);
+    if (r && r.promotion) return normalizePromotion(r.promotion);
+    return normalizePromotion(raw);
+}
+
+export async function mintChapita(
+    slug: string,
+    payload: MintChapitaPayload = {}
+): Promise<MintChapitaResponse> {
+    const res = await apiPost<unknown>(
+        `/marketplace/promotions/${encodeURIComponent(slug)}/chapitas/mint`,
+        payload
+    );
+    const raw = extractObject(res);
+    const r = asRecord(raw);
+    if (!r) return {};
+    return {
+        order_id: asString(r.order_id),
+        order_public_id: asString(r.order_public_id),
+        redirect_url: asString(r.redirect_url),
+        chapita: normalizeChapita(r.chapita) ?? undefined,
+    };
+}
+
+export async function submitFreeFormEntry(
+    slug: string,
+    payload: FreeFormEntryPayload
+): Promise<FreeFormEntryResponse> {
+    const res = await apiPost<unknown>(
+        `/marketplace/promotions/${encodeURIComponent(slug)}/entries/free-form`,
+        payload
+    );
+    const raw = extractObject(res);
+    const r = asRecord(raw);
+    if (!r) return {};
+    return {
+        id: asString(r.id),
+        created_at: asString(r.created_at),
+        message: asString(r.message),
+    };
+}
+
+export async function fetchMyChapitas(): Promise<Chapita[]> {
+    const res = await apiFetch<unknown>("/marketplace/me/chapitas", undefined, {
+        revalidate: 30,
+    });
+    const arr = extractArray<unknown>(res, ["chapitas", "entries"]);
+    return arr.map(normalizeChapita).filter((c): c is Chapita => c !== null);
+}
+
+export async function fetchWinners(slug: string): Promise<Winner[]> {
+    const res = await apiFetch<unknown>(
+        `/marketplace/promotions/${encodeURIComponent(slug)}/winners`,
+        undefined,
+        { revalidate: 60 }
+    );
+    const arr = extractArray<unknown>(res, ["winners"]);
+    return arr.map(normalizeWinner).filter((w): w is Winner => w !== null);
+}

--- a/lib/hooks/use-promotions.ts
+++ b/lib/hooks/use-promotions.ts
@@ -1,0 +1,76 @@
+"use client";
+
+// Hooks TanStack Query para promociones (WS-I).
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+    fetchMyChapitas,
+    fetchPromotion,
+    fetchPromotions,
+    fetchWinners,
+    mintChapita,
+    submitFreeFormEntry,
+} from "@/lib/api/promotions";
+import { useAuthStore } from "@/lib/stores/auth-store";
+import type {
+    FreeFormEntryPayload,
+    MintChapitaPayload,
+} from "@/lib/types/promotions";
+
+export function usePromotions() {
+    return useQuery({
+        queryKey: ["promotions", "list"],
+        queryFn: () => fetchPromotions(),
+        staleTime: 60_000,
+    });
+}
+
+export function usePromotion(slug: string | undefined) {
+    return useQuery({
+        queryKey: ["promotions", "detail", slug],
+        queryFn: () => fetchPromotion(slug as string),
+        enabled: !!slug,
+        staleTime: 60_000,
+    });
+}
+
+export function useMyChapitas() {
+    const isAuthed = useAuthStore((s) => !!s.accessToken);
+    return useQuery({
+        queryKey: ["promotions", "me", "chapitas"],
+        queryFn: () => fetchMyChapitas(),
+        enabled: isAuthed,
+        staleTime: 30_000,
+    });
+}
+
+export function useWinners(slug: string | undefined) {
+    return useQuery({
+        queryKey: ["promotions", "winners", slug],
+        queryFn: () => fetchWinners(slug as string),
+        enabled: !!slug,
+        staleTime: 60_000,
+    });
+}
+
+export function useMintChapita(slug: string) {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: (payload: MintChapitaPayload = {}) => mintChapita(slug, payload),
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: ["promotions", "me", "chapitas"] });
+            qc.invalidateQueries({ queryKey: ["promotions", "detail", slug] });
+        },
+    });
+}
+
+export function useSubmitFreeForm(slug: string) {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: (payload: FreeFormEntryPayload) => submitFreeFormEntry(slug, payload),
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: ["promotions", "detail", slug] });
+        },
+    });
+}

--- a/lib/types/promotions.ts
+++ b/lib/types/promotions.ts
@@ -1,0 +1,85 @@
+// Tipos de promociones (chapitas + sorteos, WS-I).
+// Alineados con commerce.promotions y endpoints /marketplace/promotions/*.
+
+export type PromotionStatus =
+    | "DRAFT"
+    | "ACTIVE"
+    | "SALES_CLOSED"
+    | "DRAWN"
+    | "DELIVERED"
+    | "CANCELLED";
+
+export interface Promotion {
+    id?: string;
+    slug: string;
+    title: string;
+    description?: string;
+    prize?: string;
+    art_url?: string;
+    image_url?: string;
+    edition_size?: number;
+    minted_count?: number;
+    price?: number;
+    status: PromotionStatus;
+    activated_at?: string;
+    sales_close_at?: string;
+    draw_at?: string;
+    bases_url?: string;
+    created_at?: string;
+}
+
+export interface Chapita {
+    id?: string;
+    promotion_id?: string;
+    promotion_slug?: string;
+    promotion_title?: string;
+    promotion_art_url?: string;
+    serial_number?: number;
+    chapita_hash: string;
+    order_id?: string;
+    order_public_id?: string;
+    minted_at?: string;
+    created_at?: string;
+}
+
+export interface FreeFormEntryPayload {
+    rut: string;
+    full_name: string;
+    email?: string;
+    comuna?: string;
+    captcha_token: string;
+}
+
+export interface FreeFormEntryResponse {
+    id?: string;
+    created_at?: string;
+    message?: string;
+}
+
+export interface MintChapitaPayload {
+    order_id?: string;
+    idempotency_key?: string;
+}
+
+export interface MintChapitaResponse {
+    order_id?: string;
+    order_public_id?: string;
+    redirect_url?: string;
+    chapita?: Chapita;
+}
+
+export interface Winner {
+    id?: string;
+    promotion_slug?: string;
+    winner_index?: number;
+    serial_number?: number;
+    chapita_hash?: string;
+    source?: "CHAPITA_PURCHASE" | "FREE_FORM";
+    full_name?: string;
+    username?: string;
+    display_name?: string;
+    draw_at?: string;
+    drawn_at?: string;
+    seed?: string;
+    salt_revealed?: string;
+}

--- a/lib/utils/rut.ts
+++ b/lib/utils/rut.ts
@@ -1,0 +1,39 @@
+// Utilidades de validacion/formato de RUT chileno.
+// Copia canonica para reuso desde varios componentes. El backend es
+// la fuente de verdad; estas funciones son solo feedback de UI.
+
+export function cleanRut(input: string): string {
+    return input.replace(/\./g, "").replace(/-/g, "").toUpperCase().trim();
+}
+
+export function computeRutDv(rutDigits: string): string {
+    let sum = 0;
+    let multiplier = 2;
+    for (let i = rutDigits.length - 1; i >= 0; i--) {
+        sum += parseInt(rutDigits[i], 10) * multiplier;
+        multiplier = multiplier === 7 ? 2 : multiplier + 1;
+    }
+    const remainder = 11 - (sum % 11);
+    if (remainder === 11) return "0";
+    if (remainder === 10) return "K";
+    return String(remainder);
+}
+
+export function isValidRut(input: string): boolean {
+    const cleaned = cleanRut(input);
+    if (cleaned.length < 2) return false;
+    const digits = cleaned.slice(0, -1);
+    const dv = cleaned.slice(-1);
+    if (!/^\d+$/.test(digits)) return false;
+    if (!/^[0-9K]$/.test(dv)) return false;
+    return computeRutDv(digits) === dv;
+}
+
+export function formatRut(input: string): string {
+    const cleaned = cleanRut(input);
+    if (cleaned.length < 2) return input;
+    const digits = cleaned.slice(0, -1);
+    const dv = cleaned.slice(-1);
+    const withDots = digits.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+    return `${withDots}-${dv}`;
+}


### PR DESCRIPTION
## Summary
- /promociones: listado de promociones activas (server component, revalidate 60s) y detalle por slug con hero + metadata.
- Detalle con pestanas: **Con compra** (muestra chapitas del user para la promo) y **Sin compra (Ley 19.496)** con formulario RUT + CAPTCHA mock.
- /mi-cuenta/chapitas: historial de chapitas del usuario con hash, serial, link a la orden y estado vacio con CTAs.
- Nuevos componentes reusables en components/promotions: PromotionCard, ChapitaHash (copy-to-clipboard), FreeFormEntryForm (valida RUT DV chileno, maneja 409/429), WinnersList.
- API client lib/api/promotions.ts y hooks TanStack Query lib/hooks/use-promotions.ts (usePromotions, usePromotion, useMyChapitas, useWinners, useMintChapita, useSubmitFreeForm).
- Util compartido lib/utils/rut.ts (isValidRut, formatRut) extraido desde SellerOnboardingModal.
- Sidebar principal: nuevo link "Promociones" con icono Gift. AccountSidebar: nuevo item "Mis chapitas".

## Test plan
- [ ] Visitar /promociones: lista renderiza cards con arte, estado, fecha sorteo, precio, chapitas restantes.
- [ ] Abrir una promo /promociones/[slug] y verificar hero + metadata + tabs (Con compra / Sin compra).
- [ ] Tab "Sin compra": validar RUT (12.345.678-5), CAPTCHA mock (RANKEAO), submit 201; reintento 429 muestra toast "Limite alcanzado"; 409 muestra "RUT ya inscrito".
- [ ] Autenticado: /mi-cuenta/chapitas lista chapitas con hash truncado; tooltip copia hash completo al portapapeles.
- [ ] Promo con status DRAWN: aparece seccion "Resultado del sorteo" con tabla de ganadores (winner_index, serial, hash revelado, seed/salt).
- [ ] Sidebar desktop/mobile: link "Promociones" destaca cuando la ruta coincide; link "Mis chapitas" en AccountSidebar.
- [ ] Build OK (npm run build) sin errores de TypeScript ni lint.

Closes WS-I